### PR TITLE
fix: apollo-upload-client を ESM import に変更 (#14)

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -40,6 +40,7 @@
   "devDependencies": {
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
+    "@types/apollo-upload-client": "^17.0.5",
     "@types/node": "^22.0.0",
     "@types/react": "^19.0.2",
     "@types/react-color": "^3.0.6",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -81,6 +81,9 @@ importers:
       '@testing-library/react':
         specifier: ^16.3.2
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@types/apollo-upload-client':
+        specifier: ^17.0.5
+        version: 17.0.5(@types/react@19.2.7)(graphql-ws@6.0.6(graphql@16.12.0)(ws@8.18.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@types/node':
         specifier: ^22.0.0
         version: 22.19.2
@@ -1330,6 +1333,9 @@ packages:
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
 
+  '@types/apollo-upload-client@17.0.5':
+    resolution: {integrity: sha512-rPKHaE4QNd06LNtBgz6hfntVO+pOQMS2yTcynrzBPg9+a/nbtJ2gus5KgzRp2rqfzmnKEc/sRGjLen/9Ot0Z2A==}
+
   '@types/aria-query@5.0.4':
     resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
@@ -1344,6 +1350,9 @@ packages:
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/extract-files@13.0.2':
+    resolution: {integrity: sha512-4sd7uDB0OVZmwH2wD6w7Qlpr2P5Pn8C9IGwnaq9aiiBDD3Lou7CwFjjkJTDYCDsEvk9zxAtmv9TaMg1lt/YJfA==}
 
   '@types/hoist-non-react-statics@3.3.7':
     resolution: {integrity: sha512-PQTyIulDkIDro8P+IHbKCsw7U2xxBYflVzW/FgWdCAePD9xGSidgA76/GeJ6lBKoblyhf9pBY763gbrN+1dI8g==}
@@ -5616,6 +5625,18 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@types/apollo-upload-client@17.0.5(@types/react@19.2.7)(graphql-ws@6.0.6(graphql@16.12.0)(ws@8.18.3))(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@apollo/client': 3.14.0(@types/react@19.2.7)(graphql-ws@6.0.6(graphql@16.12.0)(ws@8.18.3))(graphql@16.12.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@types/extract-files': 13.0.2
+      graphql: 16.12.0
+    transitivePeerDependencies:
+      - '@types/react'
+      - graphql-ws
+      - react
+      - react-dom
+      - subscriptions-transport-ws
+
   '@types/aria-query@5.0.4': {}
 
   '@types/chai@5.2.3':
@@ -5628,6 +5649,8 @@ snapshots:
   '@types/deep-eql@4.0.2': {}
 
   '@types/estree@1.0.8': {}
+
+  '@types/extract-files@13.0.2': {}
 
   '@types/hoist-non-react-statics@3.3.7(@types/react@19.2.7)':
     dependencies:

--- a/frontend/src/components/graphql/client.ts
+++ b/frontend/src/components/graphql/client.ts
@@ -5,6 +5,7 @@ import {
   NormalizedCacheObject
 } from '@apollo/client'
 import { setContext } from '@apollo/client/link/context'
+import { createUploadLink } from 'apollo-upload-client'
 
 type GetAccessTokenFn = (
   isAuthenticated: boolean,
@@ -32,7 +33,6 @@ export const createClient = async (
     }
   })
 
-  const { createUploadLink } = require('apollo-upload-client')
   const httpLink = createUploadLink({
     uri: process.env.NEXT_PUBLIC_GRAPHQL_ENDPOINT
   })


### PR DESCRIPTION
closes .issues/14-commonjs-require-mixed.md

## 変更内容
- `frontend/src/components/graphql/client.ts` の `require('apollo-upload-client')` を ES モジュールの `import` に置換
- `@types/apollo-upload-client@^17.0.5` を devDependencies に追加（実装パッケージ `apollo-upload-client@^17.0.0` に合わせる）

## 動作確認
- [x] `pnpm run lint`
- [x] `pnpm run build`
- [x] 既存 E2E: `cd e2e && pnpm exec playwright test`(4/4 passed)
- ユーザー手動確認依頼: 不要（型・lint・build・E2E で網羅）

## メモ
- repo 全体に他の `require()` 混在がないことを `grep` で確認済み
- dev server 稼働中に `pnpm add` した場合、HMR が ESM import を再解決しないので **dev server の再起動が必要**

🤖 Generated with [Claude Code](https://claude.com/claude-code)