### PR TITLE
chore: ローカル環境では AdSense をダミー表示に差し替え (#28)

### DIFF
--- a/frontend/src/components/adsense/google-adsense-guard.ts
+++ b/frontend/src/components/adsense/google-adsense-guard.ts
@@ -1,4 +1,4 @@
-export const googleAdnsenseStyleGuard = () => {
+export const googleAdsenseStyleGuard = () => {
   // GoogleAdsenseがstyle属性を勝手に付与してくるので回避するための処理
   // see https://deep.tacoskingdom.com/blog/195
   if (process.env.NODE_ENV !== 'production') return

--- a/frontend/src/components/adsense/google-adsense-guard.ts
+++ b/frontend/src/components/adsense/google-adsense-guard.ts
@@ -1,6 +1,7 @@
 export const googleAdnsenseStyleGuard = () => {
   // GoogleAdsenseがstyle属性を勝手に付与してくるので回避するための処理
   // see https://deep.tacoskingdom.com/blog/195
+  if (process.env.NODE_ENV !== 'production') return
   document.querySelectorAll('.mut-height-guard').forEach((target) => {
     const heightChangeObserver = new MutationObserver(() => {
       ;(target as HTMLElement).style.height = ''

--- a/frontend/src/components/adsense/google-adsense.tsx
+++ b/frontend/src/components/adsense/google-adsense.tsx
@@ -2,6 +2,7 @@ import { useRouter } from 'next/router'
 import { useEffect } from 'react'
 
 const PUBLISHER_ID = '0917187897820609'
+const isProduction = process.env.NODE_ENV === 'production'
 
 type GoogleAdsenseProps = {
   slot: string
@@ -19,6 +20,7 @@ export const GoogleAdsense = ({
   const { asPath } = useRouter()
 
   useEffect(() => {
+    if (!isProduction) return
     try {
       ;((window as any).adsbygoogle = (window as any).adsbygoogle || []).push(
         {}
@@ -28,12 +30,26 @@ export const GoogleAdsense = ({
     }
   }, [asPath])
 
+  if (!isProduction) {
+    return (
+      <div key={asPath}>
+        <div
+          className='flex items-center justify-center border border-dashed border-gray-300 text-xs text-gray-500'
+          style={{ minHeight: 80, ...style }}
+          data-testid='adsense-dummy'
+        >
+          Ad (dummy)
+        </div>
+      </div>
+    )
+  }
+
   return (
     <div key={asPath}>
       <ins
         className='adsbygoogle'
         style={style}
-        data-adtest={process.env.NODE_ENV === 'production' ? 'off' : 'on'}
+        data-adtest='off'
         data-ad-client={`ca-pub-${PUBLISHER_ID}`}
         data-ad-slot={slot}
         data-ad-format={format}

--- a/frontend/src/components/adsense/google-adsense.tsx
+++ b/frontend/src/components/adsense/google-adsense.tsx
@@ -32,14 +32,12 @@ export const GoogleAdsense = ({
 
   if (!isProduction) {
     return (
-      <div key={asPath}>
-        <div
-          className='flex items-center justify-center border border-dashed border-gray-300 text-xs text-gray-500'
-          style={{ minHeight: 80, ...style }}
-          data-testid='adsense-dummy'
-        >
-          Ad (dummy)
-        </div>
+      <div
+        className='flex items-center justify-center border border-dashed border-gray-300 text-xs text-gray-500'
+        style={{ minHeight: 80 }}
+        data-testid='adsense-dummy'
+      >
+        Ad (dummy)
       </div>
     )
   }

--- a/frontend/src/components/pages/games/article/article.tsx
+++ b/frontend/src/components/pages/games/article/article.tsx
@@ -5,7 +5,7 @@ import MessageArea, {
   MessageAreaRefHandle
 } from './message-area/message-area/message-area'
 import ArticleMenu from './article-menu'
-import { googleAdnsenseStyleGuard } from '@/components/adsense/google-adsense-guard'
+import { googleAdsenseStyleGuard } from '@/components/adsense/google-adsense-guard'
 import { useMyPlayerValue, useMyselfValue } from '../game-hook'
 import DirectMessageGroupsArea from './message-area/direct-message/direct-message-groups-area'
 
@@ -28,7 +28,7 @@ const Article = () => {
   }
 
   useEffect(() => {
-    googleAdnsenseStyleGuard()
+    googleAdsenseStyleGuard()
   }, [])
 
   const myPlayer = useMyPlayerValue()

--- a/frontend/src/pages/_document.tsx
+++ b/frontend/src/pages/_document.tsx
@@ -1,14 +1,18 @@
 import { Html, Head, Main, NextScript } from 'next/document'
 
+const isProduction = process.env.NODE_ENV === 'production'
+
 export default function Document() {
   return (
     <Html>
       <Head>
-        <script
-          async
-          src='https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-0917187897820609'
-          crossOrigin='anonymous'
-        ></script>
+        {isProduction && (
+          <script
+            async
+            src='https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-0917187897820609'
+            crossOrigin='anonymous'
+          ></script>
+        )}
         <link
           rel='apple-touch-icon'
           sizes='180x180'


### PR DESCRIPTION
## Summary
- 非本番環境では `GoogleAdsense` コンポーネントをダミー要素（`Ad (dummy)` 表示の枠）として描画し、`adsbygoogle.push` の呼び出しもスキップ
- `_document.tsx` の `adsbygoogle.js` スクリプトは本番のみ読み込み
- `googleAdnsenseStyleGuard` も非本番では no-op に

Closes #28

## Test plan
- [x] `pnpm run lint`
- [x] `pnpm run build`
- [x] `pnpm exec playwright test`（4 件 pass）
- [ ] ローカル `pnpm run dev` でダミー枠が表示されレイアウト崩れがないこと
- [ ] 本番ビルドで AdSense が従来通り読み込まれること

🤖 Generated with [Claude Code](https://claude.com/claude-code)