### PR TITLE
refactor: pageSize: 100000 を FETCH_ALL_PAGE_SIZE に集約 (#23)

### DIFF
--- a/frontend/src/lib/constants.ts
+++ b/frontend/src/lib/constants.ts
@@ -1,0 +1,3 @@
+// ページネーションを実装するまでの暫定値: getServerSideProps で「全件取得」したいクエリで使用する。
+// 将来的にはページネーション or 段階ロードに置き換える。
+export const FETCH_ALL_PAGE_SIZE = 100000

--- a/frontend/src/pages/charachips.tsx
+++ b/frontend/src/pages/charachips.tsx
@@ -11,6 +11,7 @@ import {
   PageableQuery
 } from '@/lib/generated/graphql'
 import Head from 'next/head'
+import { FETCH_ALL_PAGE_SIZE } from '@/lib/constants'
 
 export const getServerSideProps = async () => {
   const client = createInnerClient()
@@ -19,7 +20,7 @@ export const getServerSideProps = async () => {
     variables: {
       query: {
         paging: {
-          pageSize: 100000,
+          pageSize: FETCH_ALL_PAGE_SIZE,
           pageNumber: 1,
           isDesc: false,
           isLatest: false

--- a/frontend/src/pages/games.tsx
+++ b/frontend/src/pages/games.tsx
@@ -9,13 +9,14 @@ import {
   GameStatus
 } from '@/lib/generated/graphql'
 import Head from 'next/head'
+import { FETCH_ALL_PAGE_SIZE } from '@/lib/constants'
 
 export const getServerSideProps = async () => {
   const client = createInnerClient()
   const { data, error } = await client.query<IndexGamesQuery>({
     query: IndexGamesDocument,
     variables: {
-      pageSize: 100000,
+      pageSize: FETCH_ALL_PAGE_SIZE,
       pageNumber: 1,
       statuses: [
         GameStatus.Cancelled,

--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -18,13 +18,14 @@ import Tip from '@/components/pages/index/tip'
 import Head from 'next/head'
 import { useAuth0 } from '@auth0/auth0-react'
 import { useModal } from '@/components/hooks/use-modal'
+import { FETCH_ALL_PAGE_SIZE } from '@/lib/constants'
 
 export const getServerSideProps = async () => {
   const client = createInnerClient()
   const { data, error } = await client.query<IndexGamesQuery>({
     query: IndexGamesDocument,
     variables: {
-      pageSize: 100000,
+      pageSize: FETCH_ALL_PAGE_SIZE,
       pageNumber: 1,
       statuses: [
         GameStatus.Opening,


### PR DESCRIPTION
## 変更内容
- `frontend/src/lib/constants.ts` に `FETCH_ALL_PAGE_SIZE = 100000` を追加
- 同一の magic number があった 3 箇所の `getServerSideProps` から参照
  - `frontend/src/pages/index.tsx`
  - `frontend/src/pages/games.tsx`
  - `frontend/src/pages/charachips.tsx`

Issue では index.tsx のみが影響範囲として記載されていたが、同じ値が他 2 箇所にも存在したためまとめて集約した（ユーザー判断）。

Closes #23

## 動作確認
- [x] pnpm run lint
- [x] pnpm run build
- [x] 既存 E2E: cd e2e && pnpm exec playwright test （4 件 pass）

🤖 Generated with [Claude Code](https://claude.com/claude-code)