### PR TITLE
test: e2e のゲーム作成シナリオの最後にステータスを終了に変更

### DIFF
--- a/e2e/tests/create-game.spec.ts
+++ b/e2e/tests/create-game.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test'
+import { test, expect, type Page } from '@playwright/test'
 
 test.use({ storageState: '.auth/user-a.json' })
 
@@ -23,4 +23,23 @@ test('ゲーム作成画面でキャラチップを選択してゲームを作�
   await expect(page.locator('h1').filter({ hasText: gameName })).toBeVisible({
     timeout: 10000
   })
+
+  // 最後にステータスを「終了」に変更
+  await changeGameStatusToFinished(page)
 })
+
+async function changeGameStatusToFinished(page: Page): Promise<void> {
+  await page
+    .locator('nav')
+    .getByRole('button', { name: 'ステータス・期間変更' })
+    .click()
+  const dialog = page.getByRole('dialog')
+  await expect(dialog).toBeVisible()
+  await dialog
+    .locator('.css-13cymwt-control, [class*="control"]')
+    .first()
+    .click()
+  await page.getByRole('option', { name: '終了' }).click()
+  await dialog.locator('input[type="submit"][value="更新"]').first().click()
+  await page.waitForLoadState('networkidle')
+}

--- a/e2e/tests/dm-and-favorite.spec.ts
+++ b/e2e/tests/dm-and-favorite.spec.ts
@@ -11,6 +11,7 @@ import { test, expect, type Page } from '@playwright/test'
 //   7. ユーザーBがユーザーAと自分のダイレクトメッセージグループを作成
 //   8. ユーザーBが作成したダイレクトメッセージグループで発言
 //   9. ユーザーAがダイレクトメッセージグループの発言を参照
+//  10. ユーザーAがゲームのステータスを「終了」に変更
 // ================================================================
 
 test('複数ユーザーシナリオ：いいね・フォロー・DMグループ作成・DM発言・DM参照', async ({
@@ -140,6 +141,15 @@ test('複数ユーザーシナリオ：いいね・フォロー・DMグループ
   await expect(dmAreaA.getByText(bDirect).first()).toBeVisible({
     timeout: 10_000
   })
+
+  // ============================================================
+  // 10. ユーザーA: ステータスを「終了」に変更
+  // ============================================================
+  await pageA.goto(`/chat-role-play/games/${gameId}`)
+  await expect(pageA.locator('h1').filter({ hasText: gameName })).toBeVisible({
+    timeout: 10_000
+  })
+  await changeGameStatusToFinished(pageA)
 })
 
 // ================================================================
@@ -187,6 +197,14 @@ async function postNormalTalk(page: Page, text: string): Promise<void> {
 }
 
 async function changeGameStatusToRecruiting(page: Page): Promise<void> {
+  await changeGameStatus(page, '参加者募集中')
+}
+
+async function changeGameStatusToFinished(page: Page): Promise<void> {
+  await changeGameStatus(page, '終了')
+}
+
+async function changeGameStatus(page: Page, statusName: string): Promise<void> {
   await page
     .locator('nav')
     .getByRole('button', { name: 'ステータス・期間変更' })
@@ -197,7 +215,7 @@ async function changeGameStatusToRecruiting(page: Page): Promise<void> {
     .locator('.css-13cymwt-control, [class*="control"]')
     .first()
     .click()
-  await page.getByRole('option', { name: '参加者募集中' }).click()
+  await page.getByRole('option', { name: statusName }).click()
   await dialog.locator('input[type="submit"][value="更新"]').first().click()
   await page.waitForLoadState('networkidle')
 }

--- a/e2e/tests/game-flow.spec.ts
+++ b/e2e/tests/game-flow.spec.ts
@@ -13,6 +13,7 @@ import { test, expect, type Page } from '@playwright/test'
 //   9. ユーザーBがユーザーAの通常発言にリプライ
 //  10. ユーザーBがユーザーAに秘話送信
 //  11. ユーザーAが自分宛タブで秘話を確認
+//  12. ユーザーAがゲームのステータスを「終了」に変更
 // ================================================================
 
 test('複数ユーザーシナリオ：ゲーム作成・参加・発言・リプライ・秘話', async ({
@@ -125,6 +126,9 @@ test('複数ユーザーシナリオ：ゲーム作成・参加・発言・リ�
   await expect(
     pageA.locator('#message-area-tome').getByText(bSecret)
   ).toBeVisible({ timeout: 10_000 })
+
+  // 12. ユーザーA: ステータスを「終了」に変更
+  await changeGameStatusToFinished(pageA)
 })
 
 // ================================================================
@@ -193,6 +197,14 @@ async function postDescription(page: Page, text: string): Promise<void> {
 }
 
 async function changeGameStatusToRecruiting(page: Page): Promise<void> {
+  await changeGameStatus(page, '参加者募集中')
+}
+
+async function changeGameStatusToFinished(page: Page): Promise<void> {
+  await changeGameStatus(page, '終了')
+}
+
+async function changeGameStatus(page: Page, statusName: string): Promise<void> {
   await page
     .locator('nav')
     .getByRole('button', { name: 'ステータス・期間変更' })
@@ -205,7 +217,7 @@ async function changeGameStatusToRecruiting(page: Page): Promise<void> {
     .locator('.css-13cymwt-control, [class*="control"]')
     .first()
     .click()
-  await page.getByRole('option', { name: '参加者募集中' }).click()
+  await page.getByRole('option', { name: statusName }).click()
   // 「更新」ボタン（最初のフォームのsubmit）
   await dialog.locator('input[type="submit"][value="更新"]').first().click()
   // page reload される


### PR DESCRIPTION
## 変更内容

ゲーム作成を含む 3 つの E2E シナリオの末尾で、ユーザーAがゲームのステータスを「終了」に更新して終わるようにした。

- `e2e/tests/create-game.spec.ts`: 作成・遷移確認後に `changeGameStatusToFinished` を呼び出し
- `e2e/tests/game-flow.spec.ts`: 既存の `changeGameStatusToRecruiting` を共通ヘルパー `changeGameStatus(page, statusName)` ベースに整理し、シナリオ末尾で終了へ変更
- `e2e/tests/dm-and-favorite.spec.ts`: 同様に整理。DMタブから本編に戻ってから終了へ変更

## 動作確認

- [x] `cd e2e && pnpm exec playwright test` → 4 件すべて pass（26.1s）

🤖 Generated with [Claude Code](https://claude.com/claude-code)