### PR TITLE
chore: playwright に webServer 設定を追加 (#09)

### DIFF
--- a/.claude/commands/e2e.md
+++ b/.claude/commands/e2e.md
@@ -7,11 +7,11 @@ e2e テストを実行し、結果を報告する。
 
 ## 実行前提
 
-- backend (`http://localhost:8080`) が起動している
-- frontend (`http://localhost:3000`) が起動している
+- **backend (`http://localhost:8080`) が起動している**（docker-compose の MySQL も含む）
+- frontend は playwright の webServer 設定で `next dev -p 3001` を**毎回 fresh に自動起動**するため、ユーザーが手動で起動する必要はない（通常の dev server が 3000 で動いていても競合しない）
 - `e2e/.env.e2e` に Auth0 設定とテストユーザー認証情報がある
 
-実行前に backend/frontend の起動確認を行い、起動していなければユーザーに確認を取る。
+実行前に backend の起動確認のみ行い、起動していなければユーザーに確認を取る。frontend は触らない。
 
 ## 結果報告
 

--- a/.claude/skills/e2e/SKILL.md
+++ b/.claude/skills/e2e/SKILL.md
@@ -11,8 +11,9 @@ Playwright + Chromium のE2Eテスト一式は `e2e/` 配下にある。ロー�
 
 ```
 e2e/
-  global-setup.ts      # Auth0 ROPGでアクセストークン取得→storageStateを2ユーザー分作る
-  playwright.config.ts # baseURL=http://localhost:3000, workers=1, fullyParallel=false
+  global-setup.ts      # Auth0 ROPGでアクセストークン取得→storageStateを2ユーザー分作る + 主要ルートの warmup
+  playwright.config.ts # baseURL=http://localhost:3001, webServer 設定で frontend を自動起動, workers=1, fullyParallel=false
+  config.ts            # FRONTEND_PORT(3001) / BACKEND_PORT(8080) を共有
   tsconfig.json
   package.json         # pnpm
   .env.e2e             # Auth0設定とテストユーザー認証情報（gitignore）
@@ -34,7 +35,14 @@ pnpm exec playwright test --ui                 # UI mode
 pnpm exec playwright test --debug              # ステップ実行
 ```
 
-実行前に backend (8080) と frontend (3000) が起動している必要がある。Authentication state は globalSetup が毎回作り直す（ROPGでトークン取得→localStorageに `@@auth0spajs@@::...` を埋める→ `auth0.{clientId}.is.authenticated` cookie もセット）。
+## 起動前提
+
+- **backend (8080)**: 起動している必要あり。docker-compose の MySQL も含めて事前起動する。playwright は backend を `reuseExistingServer: true` で扱うので、起動していなければ自動起動を試みるが、Go 環境差異で失敗することがあるため事前起動推奨
+- **frontend**: playwright が `next dev -p 3001` で**毎回 fresh に起動**する（`reuseExistingServer: false`）。**通常の dev server (3000) を別途立ち上げていてもポート競合しない**。E2E が HMR の stale chunks 問題に巻き込まれない設計
+
+backend CORS は `http://localhost:3000` と `http://localhost:3001` の両方を許可済み（`backend/main.go`）。
+
+Authentication state は globalSetup が毎回作り直す（ROPGでトークン取得→localStorageに `@@auth0spajs@@::...` を埋める→ `auth0.{clientId}.is.authenticated` cookie もセット）。続けて主要ルート（`/chat-role-play`, `/chat-role-play/create-game`）に warmup fetch を投げて next dev の lazy compile を先回りさせる。
 
 ## テスト設計の前提
 

--- a/backend/main.go
+++ b/backend/main.go
@@ -21,7 +21,7 @@ func main() {
 	srv := inject.InjectServer()
 
 	handler := cors.New(cors.Options{
-		AllowedOrigins:   []string{"http://localhost:3000"},
+		AllowedOrigins:   []string{"http://localhost:3000", "http://localhost:3001"},
 		AllowCredentials: true,
 		AllowedHeaders:   []string{"Authorization", "Content-Type"},
 	}).Handler(srv)

--- a/e2e/config.ts
+++ b/e2e/config.ts
@@ -1,0 +1,3 @@
+// playwright.config.ts と global-setup.ts で共有するための定数
+export const FRONTEND_PORT = 3001
+export const BACKEND_PORT = 8080

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -1,6 +1,7 @@
 import { chromium } from '@playwright/test'
 import * as dotenv from 'dotenv'
 import * as path from 'path'
+import { FRONTEND_PORT } from './config'
 
 dotenv.config({ path: path.resolve(__dirname, '.env.e2e') })
 
@@ -15,7 +16,7 @@ const USER_A_PASSWORD = process.env.E2E_USER_A_PASSWORD!
 const USER_B_EMAIL = process.env.E2E_USER_B_EMAIL!
 const USER_B_PASSWORD = process.env.E2E_USER_B_PASSWORD!
 
-const BASE_URL = 'http://localhost:3001/chat-role-play'
+const BASE_URL = `http://localhost:${FRONTEND_PORT}/chat-role-play`
 
 type RopgResponse = {
   access_token: string
@@ -134,8 +135,12 @@ async function warmupRoutes(): Promise<void> {
   // E2E で使う主要ルートを先に踏んでおいてテスト本体の cold compile タイムアウトを避ける
   const routes = ['/chat-role-play', '/chat-role-play/create-game']
   for (const route of routes) {
+    const url = `http://localhost:${FRONTEND_PORT}${route}`
     try {
-      await fetch(`http://localhost:3001${route}`)
+      const res = await fetch(url)
+      if (!res.ok) {
+        console.warn(`warmup got ${res.status} for ${route}`)
+      }
     } catch (e) {
       console.warn(`warmup failed for ${route}:`, e)
     }

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -15,7 +15,7 @@ const USER_A_PASSWORD = process.env.E2E_USER_A_PASSWORD!
 const USER_B_EMAIL = process.env.E2E_USER_B_EMAIL!
 const USER_B_PASSWORD = process.env.E2E_USER_B_PASSWORD!
 
-const BASE_URL = 'http://localhost:3000/chat-role-play'
+const BASE_URL = 'http://localhost:3001/chat-role-play'
 
 type RopgResponse = {
   access_token: string
@@ -129,6 +129,19 @@ async function saveStorageState(
   await browser.close()
 }
 
+async function warmupRoutes(): Promise<void> {
+  // next dev は初回アクセス時にルートを lazy compile するため、
+  // E2E で使う主要ルートを先に踏んでおいてテスト本体の cold compile タイムアウトを避ける
+  const routes = ['/chat-role-play', '/chat-role-play/create-game']
+  for (const route of routes) {
+    try {
+      await fetch(`http://localhost:3001${route}`)
+    } catch (e) {
+      console.warn(`warmup failed for ${route}:`, e)
+    }
+  }
+}
+
 export default async function globalSetup() {
   console.log('Fetching Auth0 tokens via ROPG...')
 
@@ -144,4 +157,7 @@ export default async function globalSetup() {
   await saveStorageState(cacheB, path.resolve(__dirname, '.auth/user-b.json'))
 
   console.log('Auth state saved: .auth/user-a.json, .auth/user-b.json')
+
+  console.log('Warming up Next.js dev server routes...')
+  await warmupRoutes()
 }

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -1,8 +1,7 @@
 import { defineConfig, devices } from '@playwright/test'
+import { FRONTEND_PORT, BACKEND_PORT } from './config'
 
 // E2E では HMR の stale chunks を避けるため、本来の dev server (3000) とは別ポートで毎回 fresh に立ち上げる
-const FRONTEND_PORT = 3001
-const BACKEND_PORT = 8080
 
 export default defineConfig({
   testDir: './tests',

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -1,5 +1,9 @@
 import { defineConfig, devices } from '@playwright/test'
 
+// E2E では HMR の stale chunks を避けるため、本来の dev server (3000) とは別ポートで毎回 fresh に立ち上げる
+const FRONTEND_PORT = 3001
+const BACKEND_PORT = 8080
+
 export default defineConfig({
   testDir: './tests',
   globalSetup: './global-setup.ts',
@@ -8,9 +12,28 @@ export default defineConfig({
   workers: 1,
   reporter: 'list',
   use: {
-    baseURL: 'http://localhost:3000',
-    trace: 'on-first-retry'
+    baseURL: `http://localhost:${FRONTEND_PORT}`,
+    trace: 'on-first-retry',
+    // next dev は初回アクセス時にルートを lazy compile するため、cold start 用に余裕を持たせる
+    navigationTimeout: 60_000,
+    actionTimeout: 30_000
   },
+  webServer: [
+    {
+      command: `pnpm exec next dev -p ${FRONTEND_PORT}`,
+      cwd: '../frontend',
+      url: `http://localhost:${FRONTEND_PORT}/chat-role-play`,
+      reuseExistingServer: false,
+      timeout: 120 * 1000
+    },
+    {
+      command: 'go run main.go',
+      cwd: '../backend',
+      url: `http://localhost:${BACKEND_PORT}/crp-server/`,
+      reuseExistingServer: true,
+      timeout: 120 * 1000
+    }
+  ],
   projects: [
     {
       name: 'chromium',


### PR DESCRIPTION
## 変更内容
- E2E 専用に `next dev -p 3001` を毎回 fresh 起動（`reuseExistingServer: false`）
  - HMR の stale chunks 問題が E2E に波及しなくなる
  - 通常の dev server (3000) と並走可能
- backend は既存プロセスを再利用（`reuseExistingServer: true`）
- backend CORS に `http://localhost:3001` を追加
- `next dev` の cold compile 用に `navigationTimeout: 60s` / `actionTimeout: 30s` に延長
- `globalSetup` に主要ルート（`/chat-role-play`, `/chat-role-play/create-game`）の warmup を追加

## トレードオフ
- E2E 起動コスト: dev server fresh 起動分で +5〜10 秒程度（warmup 含め 30 秒で完走）
- backend は CI 等で起動していない場合のみ playwright が起動。DB（MySQL）の起動は引き続き docker-compose 側

Closes #09

## 動作確認
- [x] cd e2e && pnpm exec playwright test （4 件 pass、30 秒）
- [x] backend 再起動後の CORS で frontend@3001 から GraphQL が通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)