### PR TITLE
fix: <Link> 内の <button> ネストを解消 (#21)

### DIFF
--- a/frontend/src/components/pages/games/sidebar/sidebar.tsx
+++ b/frontend/src/components/pages/games/sidebar/sidebar.tsx
@@ -217,11 +217,12 @@ const UserSettingsButton = () => {
 
 const TopPageButton = () => (
   <div>
-    <Link href='/'>
-      <button className='sidebar-hover sidebar-text flex w-full justify-start px-4 py-2 text-sm'>
-        <HomeIcon className='mr-1 size-5' />
-        <p className='flex-1 self-center text-left'>トップ画面</p>
-      </button>
+    <Link
+      href='/'
+      className='sidebar-hover sidebar-text flex w-full justify-start px-4 py-2 text-sm'
+    >
+      <HomeIcon className='mr-1 size-5' />
+      <p className='flex-1 self-center text-left'>トップ画面</p>
     </Link>
   </div>
 )

--- a/frontend/src/components/pages/page-header.tsx
+++ b/frontend/src/components/pages/page-header.tsx
@@ -9,7 +9,11 @@ type Props = {
 export default function PageHeader(props: Props) {
   return (
     <div className='relative mb-2 border-b border-gray-300 py-2 text-center'>
-      <Link className='absolute start-0 block px-2' href={props.href}>
+      <Link
+        className='absolute start-0 block px-2'
+        href={props.href}
+        aria-label='戻る'
+      >
         <ArrowLeftIcon className='size-6' />
       </Link>
       <h2 className='text-xl font-bold'>{props.header}</h2>

--- a/frontend/src/components/pages/page-header.tsx
+++ b/frontend/src/components/pages/page-header.tsx
@@ -10,9 +10,7 @@ export default function PageHeader(props: Props) {
   return (
     <div className='relative mb-2 border-b border-gray-300 py-2 text-center'>
       <Link className='absolute start-0 block px-2' href={props.href}>
-        <button>
-          <ArrowLeftIcon className='size-6' />
-        </button>
+        <ArrowLeftIcon className='size-6' />
       </Link>
       <h2 className='text-xl font-bold'>{props.header}</h2>
     </div>


### PR DESCRIPTION
closes .issues/21-link-button-html-violation.md

## 変更内容

- `frontend/src/components/pages/games/sidebar/sidebar.tsx` の `TopPageButton` で `<Link>` 直下にあった `<button>` を取り除き、スタイルを `<Link>` 自体に付与
- 同パターンが `frontend/src/components/pages/page-header.tsx` にもあったため同時に修正（戻るアイコンの `<button>` を撤去）

## 動作確認

- [x] pnpm run lint
- [x] pnpm run build
- [x] 既存 E2E: cd e2e && pnpm exec playwright test （4 passed）

🤖 Generated with [Claude Code](https://claude.com/claude-code)