### PR TITLE
docs: リリースノートにメンテナンス項目を追加

### DIFF
--- a/frontend/src/pages/release-note.tsx
+++ b/frontend/src/pages/release-note.tsx
@@ -25,6 +25,10 @@ export default function CreateGame() {
 
           <hr />
 
+          <ReleaseContent label='メンテナンス' date='2026/05/09'>
+            <li>今後の変更に向けて大リファクタリング大会を実施中</li>
+          </ReleaseContent>
+
           <ReleaseContent label='UI改修/機能拡張' date='2024/03/05'>
             <li>UI変更: 会話ツリー閲覧機能を追加</li>
             <li>


### PR DESCRIPTION
## 変更内容

- `frontend/src/pages/release-note.tsx` に「2026/05/09 メンテナンス: 大リファクタリング大会」を追記

## 補足

当初は同 PR で codegen 出力 (`frontend/src/lib/generated/`) の同期も行う予定だったが、`pnpm run codegen` を実行すると working tree が clean になることを確認したため、generated/ の同期は不要だった。lint/build 時に prettier 等のフォーマッタが一時的に触っていたのみと推測。

## 動作確認

- [x] pnpm run lint
- [ ] 既存 E2E: ドキュメント変更のため対象外

🤖 Generated with [Claude Code](https://claude.com/claude-code)