### PR TITLE
refactor: 不要な型アサーションを整理 (#17)

### DIFF
--- a/frontend/src/components/adsense/google-adsense.tsx
+++ b/frontend/src/components/adsense/google-adsense.tsx
@@ -22,9 +22,9 @@ export const GoogleAdsense = ({
   useEffect(() => {
     if (!isProduction) return
     try {
-      ;((window as any).adsbygoogle = (window as any).adsbygoogle || []).push(
-        {}
-      )
+      const w = window as unknown as { adsbygoogle: unknown[] }
+      w.adsbygoogle = w.adsbygoogle || []
+      w.adsbygoogle.push({})
     } catch (error) {
       console.log(error)
     }

--- a/frontend/src/components/pages/create-game/game-edit.tsx
+++ b/frontend/src/components/pages/create-game/game-edit.tsx
@@ -9,8 +9,6 @@ import { QuestionMarkCircleIcon } from '@heroicons/react/24/outline'
 import Modal from '@/components/modal/modal'
 import { useModal } from '@/components/hooks/use-modal'
 import {
-  Charachip,
-  CharachipsQuery,
   QCharachipsDocument,
   QCharachipsQuery,
   QCharachipsQueryVariables
@@ -54,7 +52,6 @@ export interface GameFormInput {
   startGameAt: string
   epilogueGameAt: string
   finishGameAt: string
-  charachipIds: string[]
   periodPrefix: string
   periodSuffix: string
   periodIntervalDays: number
@@ -65,17 +62,22 @@ export interface GameFormInput {
 }
 
 export default function GameEdit(props: Props) {
-  const [charachips, setCharachips] = useState<Charachip[]>([])
-  const [fetchCharachips] = useLazyQuery<QCharachipsQuery>(QCharachipsDocument)
+  const [charachips, setCharachips] = useState<QCharachipsQuery['charachips']>(
+    []
+  )
+  const [fetchCharachips] = useLazyQuery<
+    QCharachipsQuery,
+    QCharachipsQueryVariables
+  >(QCharachipsDocument)
   useEffect(() => {
     const fetch = async () => {
       const { data } = await fetchCharachips({
         variables: {
-          query: {} as CharachipsQuery
-        } as QCharachipsQueryVariables
+          query: {}
+        }
       })
       if (data?.charachips) {
-        setCharachips(data.charachips as Charachip[])
+        setCharachips(data.charachips)
       }
     }
     fetch()

--- a/frontend/src/components/pages/games/article/article.tsx
+++ b/frontend/src/components/pages/games/article/article.tsx
@@ -14,15 +14,15 @@ const Article = () => {
   const [existsHomeUnread, setExistsHomeUnread] = useState(false)
   const [existsToMeUnread, setExistsToMeUnread] = useState(false)
 
-  const homeRef = useRef({} as MessageAreaRefHandle)
-  const toMeRef = useRef({} as MessageAreaRefHandle)
+  const homeRef = useRef<MessageAreaRefHandle>(null)
+  const toMeRef = useRef<MessageAreaRefHandle>(null)
 
   const handleTabChange = (tab: string) => {
     setTab(tab)
     if (tab === 'home' && existsHomeUnread) {
-      homeRef.current.fetchLatest()
+      homeRef.current?.fetchLatest()
     } else if (tab === 'tome' && existsToMeUnread) {
-      toMeRef.current.fetchLatest()
+      toMeRef.current?.fetchLatest()
     } else {
     }
   }

--- a/frontend/src/components/pages/games/article/message-area/direct-message/create-participant-group.tsx
+++ b/frontend/src/components/pages/games/article/message-area/direct-message/create-participant-group.tsx
@@ -2,7 +2,6 @@ import PrimaryButton from '@/components/button/primary-button'
 import {
   GameParticipant,
   GameParticipantGroup,
-  NewGameParticipantGroup,
   RegisterParticipantGroupDocument,
   RegisterParticipantGroupMutation,
   RegisterParticipantGroupMutationVariables
@@ -28,18 +27,18 @@ export default function CreateParticipantGroup({
 }: Props) {
   const game = useGameValue()
   const myself = useMyselfValue()!
-  const [register] = useMutation<RegisterParticipantGroupMutation>(
-    RegisterParticipantGroupDocument,
-    {
-      onCompleted(e) {
-        refetchGroups()
-        close()
-      },
-      onError(error) {
-        console.error(error)
-      }
+  const [register] = useMutation<
+    RegisterParticipantGroupMutation,
+    RegisterParticipantGroupMutationVariables
+  >(RegisterParticipantGroupDocument, {
+    onCompleted(e) {
+      refetchGroups()
+      close()
+    },
+    onError(error) {
+      console.error(error)
     }
-  )
+  })
   const [participants, setParticipants] = useState<Array<GameParticipant>>([])
   const [submitting, setSubmitting] = useState(false)
   const handleRegister = useCallback(() => {
@@ -52,8 +51,8 @@ export default function CreateParticipantGroup({
           gameId: game.id,
           name: name.length > 30 ? name.substring(0, 30) + '…' : name,
           gameParticipantIds: pts.map((p) => p.id)
-        } as NewGameParticipantGroup
-      } as RegisterParticipantGroupMutationVariables
+        }
+      }
     }).then((res) => {
       setSubmitting(false)
     })

--- a/frontend/src/components/pages/games/article/message-area/direct-message/direct-favorite-button.tsx
+++ b/frontend/src/components/pages/games/article/message-area/direct-message/direct-favorite-button.tsx
@@ -4,12 +4,10 @@ import {
   useMyselfValue
 } from '@/components/pages/games/game-hook'
 import {
-  DeleteMessageFavorite,
   DirectMessage,
   FavoriteDocument,
   FavoriteMutation,
   FavoriteMutationVariables,
-  NewMessageFavorite,
   UnfavoriteDocument,
   UnfavoriteMutation,
   UnfavoriteMutationVariables
@@ -37,16 +35,22 @@ export default function DirectFavoriteButton({ message }: Props) {
     message.reactions.favoriteCounts
   )
 
-  const [favorite] = useMutation<FavoriteMutation>(FavoriteDocument, {
-    onCompleted(_) {
-      setIsFav(true)
-      setFavCount(favCount + 1)
-    },
-    onError(error) {
-      console.error(error)
+  const [favorite] = useMutation<FavoriteMutation, FavoriteMutationVariables>(
+    FavoriteDocument,
+    {
+      onCompleted(_) {
+        setIsFav(true)
+        setFavCount(favCount + 1)
+      },
+      onError(error) {
+        console.error(error)
+      }
     }
-  })
-  const [unfavorite] = useMutation<UnfavoriteMutation>(UnfavoriteDocument, {
+  )
+  const [unfavorite] = useMutation<
+    UnfavoriteMutation,
+    UnfavoriteMutationVariables
+  >(UnfavoriteDocument, {
     onCompleted(_) {
       setIsFav(false)
       setFavCount(favCount - 1)
@@ -64,8 +68,8 @@ export default function DirectFavoriteButton({ message }: Props) {
           input: {
             gameId: game.id,
             messageId: message.id
-          } as DeleteMessageFavorite
-        } as UnfavoriteMutationVariables
+          }
+        }
       })
     } else {
       favorite({
@@ -73,8 +77,8 @@ export default function DirectFavoriteButton({ message }: Props) {
           input: {
             gameId: game.id,
             messageId: message.id
-          } as NewMessageFavorite
-        } as FavoriteMutationVariables
+          }
+        }
       })
     }
   }, [isFav, favorite, unfavorite, canFav, game.id, message.id])

--- a/frontend/src/components/pages/games/article/message-area/direct-message/direct-favorite-participants.tsx
+++ b/frontend/src/components/pages/games/article/message-area/direct-message/direct-favorite-participants.tsx
@@ -17,16 +17,16 @@ type Props = {
 export default function DirectFavoriteParticipants({ messageId }: Props) {
   const game = useGameValue()
   const [participants, setParticipants] = useState<Array<GameParticipant>>([])
-  const [fetchFavoriteParticipants] =
-    useLazyQuery<DirectFavoriteParticipantsQuery>(
-      DirectFavoriteParticipantsDocument
-    )
+  const [fetchFavoriteParticipants] = useLazyQuery<
+    DirectFavoriteParticipantsQuery,
+    DirectFavoriteParticipantsQueryVariables
+  >(DirectFavoriteParticipantsDocument)
   const refetchFavoriteParticipants = async () => {
     const { data } = await fetchFavoriteParticipants({
       variables: {
         gameId: game.id,
         directMessageId: messageId
-      } as DirectFavoriteParticipantsQueryVariables
+      }
     })
     if (data?.directMessageFavoriteGameParticipants == null) return
     setParticipants(

--- a/frontend/src/components/pages/games/article/message-area/direct-message/direct-message-area.tsx
+++ b/frontend/src/components/pages/games/article/message-area/direct-message/direct-message-area.tsx
@@ -63,9 +63,10 @@ export default function DirectMessageArea(props: Props) {
     latestUnixTimeMilli: 0
   })
 
-  const [fetchDirectMessages] = useLazyQuery<GameDirectMessagesQuery>(
-    GameDirectMessagesDocument
-  )
+  const [fetchDirectMessages] = useLazyQuery<
+    GameDirectMessagesQuery,
+    GameDirectMessagesQueryVariables
+  >(GameDirectMessagesDocument)
 
   const search = useCallback(
     async (q: DirectMessagesQuery = query) => {
@@ -74,7 +75,7 @@ export default function DirectMessageArea(props: Props) {
         variables: {
           gameId: game.id,
           query: q
-        } as GameDirectMessagesQueryVariables
+        }
       })
       if (data?.directMessages == null) return
       setDirectMessages(data.directMessages as DirectMessages)
@@ -166,9 +167,12 @@ const DirectMessageModal = (
             </button>
             <p className='justify-center text-xl'>{group.name}</p>
           </div>
-          {cloneElement(props.children as any, {
-            close: close
-          })}
+          {cloneElement(
+            props.children as React.ReactElement<{ close: () => void }>,
+            {
+              close: close
+            }
+          )}
           <div id={`${props.talkAreaId}-fixed`}></div>
           <DirectFooterMenu
             group={group}
@@ -228,10 +232,10 @@ type DirectMessagesAreaProps = {
 const DirectMessagesArea = (props: DirectMessagesAreaProps) => {
   const { directMessages, query, search } = props
   const setPageableQuery = (q: PageableQuery) => {
-    const newQuery = {
+    const newQuery: DirectMessagesQuery = {
       ...query,
       paging: q
-    } as DirectMessagesQuery
+    }
     search(newQuery)
   }
 

--- a/frontend/src/components/pages/games/article/message-area/direct-message/direct-message-groups-area.tsx
+++ b/frontend/src/components/pages/games/article/message-area/direct-message/direct-message-groups-area.tsx
@@ -1,8 +1,8 @@
 import {
   GameParticipantGroup,
-  GameParticipantGroupsQuery,
   ParticipantGroupsDocument,
-  ParticipantGroupsQuery
+  ParticipantGroupsQuery,
+  ParticipantGroupsQueryVariables
 } from '@/lib/generated/graphql'
 import { useEffect, useState } from 'react'
 import { useModal } from '@/components/hooks/use-modal'
@@ -25,9 +25,10 @@ type Props = {
 export default function DirectMessageGroupsArea({ className }: Props) {
   const game = useGameValue()
   const myself = useMyselfValue()!
-  const [fetchParticipantGroups] = useLazyQuery<ParticipantGroupsQuery>(
-    ParticipantGroupsDocument
-  )
+  const [fetchParticipantGroups] = useLazyQuery<
+    ParticipantGroupsQuery,
+    ParticipantGroupsQueryVariables
+  >(ParticipantGroupsDocument)
   const [groups, setGroups] = useState<GameParticipantGroup[]>([])
 
   const createModal = useModal()
@@ -45,7 +46,7 @@ export default function DirectMessageGroupsArea({ className }: Props) {
       variables: {
         gameId: game.id,
         participantId: myself?.id
-      } as GameParticipantGroupsQuery
+      }
     })
     if (data?.gameParticipantGroups == null) return
     const newGroups = (

--- a/frontend/src/components/pages/games/article/message-area/direct-message/direct-message.tsx
+++ b/frontend/src/components/pages/games/article/message-area/direct-message/direct-message.tsx
@@ -1,10 +1,8 @@
 import {
-  DeleteDirectMessageFavorite,
   DirectMessage,
   FavoriteDirectDocument,
   FavoriteDirectMutation,
   FavoriteDirectMutationVariables,
-  NewDirectMessageFavorite,
   UnfavoriteDirectDocument,
   UnfavoriteDirectMutation,
   UnfavoriteDirectMutationVariables
@@ -54,30 +52,30 @@ export default memo(function DirectMessageComponent({
     ? 'hover:text-yellow-500 secondary-text'
     : 'secondary-text'
 
-  const [favorite] = useMutation<FavoriteDirectMutation>(
-    FavoriteDirectDocument,
-    {
-      onCompleted(_) {
-        setIsFav(true)
-        setFavCount(favCount + 1)
-      },
-      onError(error) {
-        console.error(error)
-      }
+  const [favorite] = useMutation<
+    FavoriteDirectMutation,
+    FavoriteDirectMutationVariables
+  >(FavoriteDirectDocument, {
+    onCompleted(_) {
+      setIsFav(true)
+      setFavCount(favCount + 1)
+    },
+    onError(error) {
+      console.error(error)
     }
-  )
-  const [unfavorite] = useMutation<UnfavoriteDirectMutation>(
-    UnfavoriteDirectDocument,
-    {
-      onCompleted(_) {
-        setIsFav(false)
-        setFavCount(favCount - 1)
-      },
-      onError(error) {
-        console.error(error)
-      }
+  })
+  const [unfavorite] = useMutation<
+    UnfavoriteDirectMutation,
+    UnfavoriteDirectMutationVariables
+  >(UnfavoriteDirectDocument, {
+    onCompleted(_) {
+      setIsFav(false)
+      setFavCount(favCount - 1)
+    },
+    onError(error) {
+      console.error(error)
     }
-  )
+  })
 
   const handleFav = useCallback(() => {
     if (!canFav) return
@@ -87,8 +85,8 @@ export default memo(function DirectMessageComponent({
           input: {
             gameId: game.id,
             directMessageId: directMessage.id
-          } as DeleteDirectMessageFavorite
-        } as UnfavoriteDirectMutationVariables
+          }
+        }
       })
     } else {
       favorite({
@@ -96,8 +94,8 @@ export default memo(function DirectMessageComponent({
           input: {
             gameId: game.id,
             directMessageId: directMessage.id
-          } as NewDirectMessageFavorite
-        } as FavoriteDirectMutationVariables
+          }
+        }
       })
     }
   }, [isFav, favorite, unfavorite, canFav, game.id, directMessage.id])

--- a/frontend/src/components/pages/games/article/message-area/direct-message/participant-group-edit.tsx
+++ b/frontend/src/components/pages/games/article/message-area/direct-message/participant-group-edit.tsx
@@ -3,7 +3,6 @@ import InputText from '@/components/form/input-text'
 import { useGameValue } from '@/components/pages/games/game-hook'
 import {
   GameParticipantGroup,
-  UpdateGameParticipantGroup,
   UpdateParticipantGroupDocument,
   UpdateParticipantGroupMutation,
   UpdateParticipantGroupMutationVariables
@@ -34,18 +33,18 @@ export default function ParticipantGroupEdit({
     }
   })
   const canSubmit: boolean = formState.isValid && !formState.isSubmitting
-  const [updateGroup] = useMutation<UpdateParticipantGroupMutation>(
-    UpdateParticipantGroupDocument,
-    {
-      onCompleted(e) {
-        refetchGroups()
-        close()
-      },
-      onError(error) {
-        console.error(error)
-      }
+  const [updateGroup] = useMutation<
+    UpdateParticipantGroupMutation,
+    UpdateParticipantGroupMutationVariables
+  >(UpdateParticipantGroupDocument, {
+    onCompleted(e) {
+      refetchGroups()
+      close()
+    },
+    onError(error) {
+      console.error(error)
     }
-  )
+  })
 
   const onSubmit: SubmitHandler<FormInput> = useCallback(
     (data) => {
@@ -55,8 +54,8 @@ export default function ParticipantGroupEdit({
             gameId: game.id,
             id: group.id,
             name: data.name
-          } as UpdateGameParticipantGroup
-        } as UpdateParticipantGroupMutationVariables
+          }
+        }
       })
     },
     [updateGroup, group, game.id]

--- a/frontend/src/components/pages/games/article/message-area/message-area/message-area.tsx
+++ b/frontend/src/components/pages/games/article/message-area/message-area/message-area.tsx
@@ -1,7 +1,7 @@
 import {
   GameMessagesDocument,
   GameMessagesQuery,
-  Message,
+  GameMessagesQueryVariables,
   Messages,
   MessagesQuery
 } from '@/lib/generated/graphql'
@@ -64,8 +64,10 @@ const MessageArea = forwardRef<MessageAreaRefHandle, Props>(
     })
     const [latestTime, setLatestTime] = useState<number>(0)
 
-    const [fetchMessages] =
-      useLazyQuery<GameMessagesQuery>(GameMessagesDocument)
+    const [fetchMessages] = useLazyQuery<
+      GameMessagesQuery,
+      GameMessagesQueryVariables
+    >(GameMessagesDocument)
     const search = useCallback(
       async (query: MessagesQuery = messageQuery) => {
         setMessageQuery(query)
@@ -73,11 +75,11 @@ const MessageArea = forwardRef<MessageAreaRefHandle, Props>(
           variables: {
             gameId: game.id,
             query: query
-          } as MessagesQuery
+          }
         })
         if (data?.messages == null) return
         setMessages(data.messages as Messages)
-        setLatestTime(data.messages.latestUnixTimeMilli as number)
+        setLatestTime(Number(data.messages.latestUnixTimeMilli))
         setExistUnread(false)
       },
       [game.id, messageQuery, fetchMessages, setExistUnread]

--- a/frontend/src/components/pages/games/article/message-area/message-area/messages-area/message/favorite-button.tsx
+++ b/frontend/src/components/pages/games/article/message-area/message-area/messages-area/message/favorite-button.tsx
@@ -4,12 +4,10 @@ import {
   useMyselfValue
 } from '@/components/pages/games/game-hook'
 import {
-  DeleteMessageFavorite,
   FavoriteDocument,
   FavoriteMutation,
   FavoriteMutationVariables,
   Message,
-  NewMessageFavorite,
   UnfavoriteDocument,
   UnfavoriteMutation,
   UnfavoriteMutationVariables
@@ -37,16 +35,22 @@ export default function FavoriteButton({ message }: Props) {
     message.reactions.favoriteCount
   )
 
-  const [favorite] = useMutation<FavoriteMutation>(FavoriteDocument, {
-    onCompleted(_) {
-      setIsFav(true)
-      setFavCount(favCount + 1)
-    },
-    onError(error) {
-      console.error(error)
+  const [favorite] = useMutation<FavoriteMutation, FavoriteMutationVariables>(
+    FavoriteDocument,
+    {
+      onCompleted(_) {
+        setIsFav(true)
+        setFavCount(favCount + 1)
+      },
+      onError(error) {
+        console.error(error)
+      }
     }
-  })
-  const [unfavorite] = useMutation<UnfavoriteMutation>(UnfavoriteDocument, {
+  )
+  const [unfavorite] = useMutation<
+    UnfavoriteMutation,
+    UnfavoriteMutationVariables
+  >(UnfavoriteDocument, {
     onCompleted(_) {
       setIsFav(false)
       setFavCount(favCount - 1)
@@ -64,8 +68,8 @@ export default function FavoriteButton({ message }: Props) {
           input: {
             gameId: game.id,
             messageId: message.id
-          } as DeleteMessageFavorite
-        } as UnfavoriteMutationVariables
+          }
+        }
       })
     } else {
       favorite({
@@ -73,8 +77,8 @@ export default function FavoriteButton({ message }: Props) {
           input: {
             gameId: game.id,
             messageId: message.id
-          } as NewMessageFavorite
-        } as FavoriteMutationVariables
+          }
+        }
       })
     }
   }, [isFav, favorite, unfavorite, canFav, game.id, message.id])

--- a/frontend/src/components/pages/games/article/message-area/message-area/messages-area/message/favorite-participants.tsx
+++ b/frontend/src/components/pages/games/article/message-area/message-area/messages-area/message/favorite-participants.tsx
@@ -1,6 +1,7 @@
 import {
   FavoriteParticipantsDocument,
   FavoriteParticipantsQuery,
+  FavoriteParticipantsQueryVariables,
   GameParticipant
 } from '@/lib/generated/graphql'
 import { useLazyQuery } from '@apollo/client'
@@ -16,9 +17,10 @@ type Props = {
 export default function FavoriteParticipants({ messageId }: Props) {
   const game = useGameValue()
   const [participants, setParticipants] = useState<GameParticipant[]>([])
-  const [fetchFavoriteParticipants] = useLazyQuery<FavoriteParticipantsQuery>(
-    FavoriteParticipantsDocument
-  )
+  const [fetchFavoriteParticipants] = useLazyQuery<
+    FavoriteParticipantsQuery,
+    FavoriteParticipantsQueryVariables
+  >(FavoriteParticipantsDocument)
   const refetchFavoriteParticipants = async () => {
     const { data } = await fetchFavoriteParticipants({
       variables: {

--- a/frontend/src/components/pages/games/article/message-area/message-area/messages-area/message/talk-message.tsx
+++ b/frontend/src/components/pages/games/article/message-area/message-area/messages-area/message/talk-message.tsx
@@ -1,10 +1,12 @@
 import {
   GameMessageDocument,
   GameMessageQuery,
+  GameMessageQueryVariables,
   Message,
   MessageRecipient,
   MessageRepliesDocument,
   MessageRepliesQuery,
+  MessageRepliesQueryVariables,
   MessageType
 } from '@/lib/generated/graphql'
 import Image from 'next/image'
@@ -204,9 +206,10 @@ const ReplyButton = ({
 }: ReplyButtonProps) => {
   const game = useGameValue()
   const myself = useMyselfValue()
-  const [fetchReplies] = useLazyQuery<MessageRepliesQuery>(
-    MessageRepliesDocument
-  )
+  const [fetchReplies] = useLazyQuery<
+    MessageRepliesQuery,
+    MessageRepliesQueryVariables
+  >(MessageRepliesDocument)
   const toggleReplies = async () => {
     if (!showReplies && replies.length === 0) {
       const { data } = await fetchReplies({
@@ -277,7 +280,10 @@ const ReplyToMessage = ({ message }: { message: Message }) => {
     (p) => p.id === message.replyTo!.participantId
   )?.name
 
-  const [fetchMessage] = useLazyQuery<GameMessageQuery>(GameMessageDocument)
+  const [fetchMessage] = useLazyQuery<
+    GameMessageQuery,
+    GameMessageQueryVariables
+  >(GameMessageDocument)
   useEffect(() => {
     const fetch = async () => {
       const { data } = await fetchMessage({

--- a/frontend/src/components/pages/games/article/message-area/message-area/messages-area/messages-area.tsx
+++ b/frontend/src/components/pages/games/article/message-area/message-area/messages-area/messages-area.tsx
@@ -3,6 +3,7 @@ import {
   Messages,
   MessagesLatestDocument,
   MessagesLatestQuery,
+  MessagesLatestQueryVariables,
   MessagesQuery,
   PageableQuery
 } from '@/lib/generated/graphql'
@@ -45,9 +46,10 @@ const MessagesArea = (props: Props) => {
     setExistsUnread
   } = props
 
-  const [fetchMessagesLatest] = useLazyQuery<MessagesLatestQuery>(
-    MessagesLatestDocument
-  )
+  const [fetchMessagesLatest] = useLazyQuery<
+    MessagesLatestQuery,
+    MessagesLatestQueryVariables
+  >(MessagesLatestDocument)
 
   const fetchLatestTime = async () => {
     if (!isViewing && existsUnread) return
@@ -58,10 +60,10 @@ const MessagesArea = (props: Props) => {
           ...messageQuery,
           offsetUnixTimeMilli: latestTime
         }
-      } as MessagesQuery
+      }
     })
     if (data?.messagesLatestUnixTimeMilli == null) return
-    const latest = data.messagesLatestUnixTimeMilli as number
+    const latest = Number(data.messagesLatestUnixTimeMilli)
     if (latestTime < latest) {
       if (isViewing) search()
       else setExistsUnread(true)
@@ -71,10 +73,10 @@ const MessagesArea = (props: Props) => {
   usePollingMessages(() => fetchLatestTime())
 
   const setPageableQuery = (q: PageableQuery) => {
-    const newQuery = {
+    const newQuery: MessagesQuery = {
       ...messageQuery,
       paging: q
-    } as MessagesQuery
+    }
     search(newQuery)
   }
 
@@ -136,7 +138,7 @@ const GamePeriodLinksArea = (
   const { messageQuery, search, searchable } = props
 
   const setPeriodQuery = (periodId: string) => {
-    const newQuery = {
+    const newQuery: MessagesQuery = {
       ...messageQuery,
       periodId,
       paging: {
@@ -145,7 +147,7 @@ const GamePeriodLinksArea = (
         pageNumber: 1,
         isLatest: false
       } as PageableQuery
-    } as MessagesQuery
+    }
     search(newQuery)
   }
 

--- a/frontend/src/components/pages/games/article/message-area/message-area/messages-area/messages-area.tsx
+++ b/frontend/src/components/pages/games/article/message-area/message-area/messages-area/messages-area.tsx
@@ -138,15 +138,17 @@ const GamePeriodLinksArea = (
   const { messageQuery, search, searchable } = props
 
   const setPeriodQuery = (periodId: string) => {
+    // paging は MessageArea 初期化時に必ず設定済み
+    const paging = messageQuery.paging!
     const newQuery: MessagesQuery = {
       ...messageQuery,
       periodId,
       paging: {
+        ...paging,
         // 期間移動したら1ページ目に戻す
-        ...messageQuery.paging,
         pageNumber: 1,
         isLatest: false
-      } as PageableQuery
+      }
     }
     search(newQuery)
   }

--- a/frontend/src/components/pages/games/game-hook.ts
+++ b/frontend/src/components/pages/games/game-hook.ts
@@ -1,5 +1,4 @@
 import {
-  ChangePeriod,
   ChangePeriodDocument,
   ChangePeriodMutation,
   ChangePeriodMutationVariables,
@@ -8,11 +7,13 @@ import {
   GameParticipantIcon,
   IconsDocument,
   IconsQuery,
+  IconsQueryVariables,
   MyGameParticipantDocument,
   MyGameParticipantQuery,
   MyGameParticipantQueryVariables,
   MyPlayerDocument,
   MyPlayerQuery,
+  MyPlayerQueryVariables,
   Player
 } from '@/lib/generated/graphql'
 import { useLazyQuery, useMutation } from '@apollo/client'
@@ -96,13 +97,14 @@ export const useMyselfInit = (gameId: string): GameParticipant | null => {
 export const useMyself = (
   gameId: string
 ): [myself: GameParticipant | null, refetchMyself: () => void] => {
-  const [fetchMyself] = useLazyQuery<MyGameParticipantQuery>(
-    MyGameParticipantDocument
-  )
+  const [fetchMyself] = useLazyQuery<
+    MyGameParticipantQuery,
+    MyGameParticipantQueryVariables
+  >(MyGameParticipantDocument)
   const [myself, setMyselfAtom] = useAtom(myselfAtom)
   const fetch = async () => {
     const { data } = await fetchMyself({
-      variables: { gameId } as MyGameParticipantQueryVariables
+      variables: { gameId }
     })
     setMyselfAtom((data?.myGameParticipant as GameParticipant) ?? null)
   }
@@ -115,7 +117,9 @@ export const useMyselfValue = () => useAtomValue(myselfAtom)
 const myPlayerAtom = atom<Player | null>(null)
 
 export const useMyPlayer = (): Player | null => {
-  const [fetchMyPlayer] = useLazyQuery<MyPlayerQuery>(MyPlayerDocument)
+  const [fetchMyPlayer] = useLazyQuery<MyPlayerQuery, MyPlayerQueryVariables>(
+    MyPlayerDocument
+  )
   const [myPlayer, setMyPlayer] = useAtom(myPlayerAtom)
   useEffect(() => {
     const fetch = async () => {
@@ -144,7 +148,10 @@ const periodChangeStatuses = [
   'Epilogue'
 ]
 export const usePollingPeriod = (game: Game) => {
-  const [changePeriod] = useMutation<ChangePeriodMutation>(ChangePeriodDocument)
+  const [changePeriod] = useMutation<
+    ChangePeriodMutation,
+    ChangePeriodMutationVariables
+  >(ChangePeriodDocument)
 
   const callback = useCallback(async () => {
     if (!periodChangeStatuses.includes(game.status)) return
@@ -153,8 +160,8 @@ export const usePollingPeriod = (game: Game) => {
       variables: {
         input: {
           gameId: game.id
-        } as ChangePeriod
-      } as ChangePeriodMutationVariables
+        }
+      }
     })
   }, [game.status, game.id, changePeriod])
 
@@ -191,7 +198,9 @@ const iconsAtom = atom<Array<GameParticipantIcon>>([])
 export const useIcons = (): void => {
   const myself = useMyselfValue()
   const setIconsAtom = useSetAtom(iconsAtom)
-  const [fetchIcons] = useLazyQuery<IconsQuery>(IconsDocument)
+  const [fetchIcons] = useLazyQuery<IconsQuery, IconsQueryVariables>(
+    IconsDocument
+  )
   const fetch = async () => {
     if (!myself) return
     const { data } = await fetchIcons({

--- a/frontend/src/components/pages/games/profile/followers.tsx
+++ b/frontend/src/components/pages/games/profile/followers.tsx
@@ -14,14 +14,17 @@ type Props = {
 
 export default function Followers({ participantId }: Props) {
   const [followers, setFollowers] = useState<Array<GameParticipant>>([])
-  const [fetchFollowers] = useLazyQuery<FollowersQuery>(FollowersDocument)
+  const [fetchFollowers] = useLazyQuery<
+    FollowersQuery,
+    FollowersQueryVariables
+  >(FollowersDocument)
 
   useEffect(() => {
     const fetch = async () => {
       const { data } = await fetchFollowers({
         variables: {
           participantId: participantId
-        } as FollowersQueryVariables
+        }
       })
       if (data?.gameParticipantFollowers == null) return
       setFollowers(data.gameParticipantFollowers as Array<GameParticipant>)

--- a/frontend/src/components/pages/games/profile/follows.tsx
+++ b/frontend/src/components/pages/games/profile/follows.tsx
@@ -14,14 +14,16 @@ type Props = {
 
 export default function Follows({ participantId }: Props) {
   const [follows, setFollows] = useState<Array<GameParticipant>>([])
-  const [fetchFollows] = useLazyQuery<FollowsQuery>(FollowsDocument)
+  const [fetchFollows] = useLazyQuery<FollowsQuery, FollowsQueryVariables>(
+    FollowsDocument
+  )
 
   useEffect(() => {
     const fetch = async () => {
       const { data } = await fetchFollows({
         variables: {
           participantId: participantId
-        } as FollowsQueryVariables
+        }
       })
       if (data?.gameParticipantFollows == null) return
       setFollows(data.gameParticipantFollows as Array<GameParticipant>)

--- a/frontend/src/components/pages/games/profile/participant-icon-edit.tsx
+++ b/frontend/src/components/pages/games/profile/participant-icon-edit.tsx
@@ -5,7 +5,6 @@ import {
   DeleteParticipantIconMutation,
   DeleteParticipantIconMutationVariables,
   GameParticipantIcon,
-  UpdateGameParticipantIcon,
   UpdateIconDocument,
   UpdateIconMutation,
   UpdateIconMutationVariables,
@@ -122,7 +121,10 @@ const IconSortArea = ({
     setActiveIcon(undefined)
   }
   const handleDragCancel = () => setActiveIcon(undefined)
-  const [updateIcon] = useMutation<UpdateIconMutation>(UpdateIconDocument)
+  const [updateIcon] = useMutation<
+    UpdateIconMutation,
+    UpdateIconMutationVariables
+  >(UpdateIconDocument)
   const handleSaveSort = async () => {
     setSubmitting(true)
     // 並び順に変更のあったアイコンのみ更新
@@ -138,8 +140,8 @@ const IconSortArea = ({
                 gameId: game.id,
                 id: icon.id,
                 displayOrder: newDisplayOrder
-              } as UpdateGameParticipantIcon
-            } as UpdateIconMutationVariables
+              }
+            }
           })
         )
       }
@@ -261,7 +263,10 @@ const IconUploadArea = ({
   // upload new icon --------------------------------------
   const [images, setImages] = useState<File[]>([])
   const canSubmit: boolean = images.length > 0 && !submitting
-  const [uploadIcons] = useMutation<UploadIconsMutation>(UploadIconsDocument, {
+  const [uploadIcons] = useMutation<
+    UploadIconsMutation,
+    UploadIconsMutationVariables
+  >(UploadIconsDocument, {
     onCompleted(e) {
       setSubmitting(false)
       setImages([])
@@ -287,7 +292,7 @@ const IconUploadArea = ({
             width: 60,
             height: 60
           }
-        } as UploadIconsMutationVariables
+        }
       })
     },
     [uploadIcons, images, game.id, setSubmitting]
@@ -341,19 +346,19 @@ const IconDeleteArea = ({
   refetchIcons: () => Promise<Array<GameParticipantIcon>>
 }) => {
   const game = useGameValue()
-  const [deleteIcon] = useMutation<DeleteParticipantIconMutation>(
-    DeleteParticipantIconDocument,
-    {
-      onCompleted(e) {
-        refetchIcons().then((icons) => {
-          setIcons(icons)
-        })
-      },
-      onError(error) {
-        console.error(error)
-      }
+  const [deleteIcon] = useMutation<
+    DeleteParticipantIconMutation,
+    DeleteParticipantIconMutationVariables
+  >(DeleteParticipantIconDocument, {
+    onCompleted(e) {
+      refetchIcons().then((icons) => {
+        setIcons(icons)
+      })
+    },
+    onError(error) {
+      console.error(error)
     }
-  )
+  })
 
   const handleDelete = useCallback(
     (e: React.MouseEvent, iconId: string) => {
@@ -365,7 +370,7 @@ const IconDeleteArea = ({
             gameId: game.id,
             iconId: iconId
           }
-        } as DeleteParticipantIconMutationVariables
+        }
       })
     },
     [deleteIcon, game.id]

--- a/frontend/src/components/pages/games/profile/profile-edit.tsx
+++ b/frontend/src/components/pages/games/profile/profile-edit.tsx
@@ -6,7 +6,6 @@ import InputTextarea from '@/components/form/input-textarea'
 import {
   GameParticipantIcon,
   GameParticipantProfile,
-  UpdateGameParticipantProfile,
   UpdateGameParticipantProfileDocument,
   UpdateGameParticipantProfileMutation,
   UpdateGameParticipantProfileMutationVariables
@@ -55,19 +54,19 @@ export default function ProfileEdit({
   const iconSelectModal = useModal()
 
   const canSubmit: boolean = formState.isValid && !formState.isSubmitting
-  const [updateProfile] = useMutation<UpdateGameParticipantProfileMutation>(
-    UpdateGameParticipantProfileDocument,
-    {
-      onCompleted(e) {
-        refetchMyself()
-        refetchProfile()
-        close()
-      },
-      onError(error) {
-        console.error(error)
-      }
+  const [updateProfile] = useMutation<
+    UpdateGameParticipantProfileMutation,
+    UpdateGameParticipantProfileMutationVariables
+  >(UpdateGameParticipantProfileDocument, {
+    onCompleted(e) {
+      refetchMyself()
+      refetchProfile()
+      close()
+    },
+    onError(error) {
+      console.error(error)
     }
-  )
+  })
 
   const onSubmit: SubmitHandler<FormInput> = useCallback(
     (data) => {
@@ -82,8 +81,8 @@ export default function ProfileEdit({
             introduction: data.introduction,
             memo: null, // TODO: 消えてしまうかも
             isPlayerOpen: data.isPlayerOpen
-          } as UpdateGameParticipantProfile
-        } as UpdateGameParticipantProfileMutationVariables
+          }
+        }
       })
     },
     [updateProfile, images, iconId, game.id, profile.profileImageUrl]

--- a/frontend/src/components/pages/games/profile/profile.tsx
+++ b/frontend/src/components/pages/games/profile/profile.tsx
@@ -8,8 +8,10 @@ import {
   GameParticipantProfile,
   GameParticipantProfileDocument,
   GameParticipantProfileQuery,
+  GameParticipantProfileQueryVariables,
   IconsDocument,
   IconsQuery,
+  IconsQueryVariables,
   LeaveDocument,
   LeaveMutation,
   LeaveMutationVariables,
@@ -39,10 +41,13 @@ export default function Profile({ close, participantId }: Props) {
   const [profile, setProfile] = useState<GameParticipantProfile | null>(null)
   const [icons, setIcons] = useState<Array<GameParticipantIcon>>([])
 
-  const [fetchProfile] = useLazyQuery<GameParticipantProfileQuery>(
-    GameParticipantProfileDocument
+  const [fetchProfile] = useLazyQuery<
+    GameParticipantProfileQuery,
+    GameParticipantProfileQueryVariables
+  >(GameParticipantProfileDocument)
+  const [fetchIcons] = useLazyQuery<IconsQuery, IconsQueryVariables>(
+    IconsDocument
   )
-  const [fetchIcons] = useLazyQuery<IconsQuery>(IconsDocument)
 
   const refetchProfile = async () => {
     const { data } = await fetchProfile({
@@ -57,8 +62,8 @@ export default function Profile({ close, participantId }: Props) {
       variables: { participantId }
     })
     if (data?.gameParticipantIcons == null) return []
-    setIcons(data.gameParticipantIcons as Array<GameParticipantIcon>)
-    return data.gameParticipantIcons as Array<GameParticipantIcon>
+    setIcons(data.gameParticipantIcons)
+    return data.gameParticipantIcons
   }
 
   useEffect(() => {
@@ -128,14 +133,17 @@ export default function Profile({ close, participantId }: Props) {
 
 const LeaveButton = () => {
   const game = useGameValue()
-  const [leave] = useMutation<LeaveMutation>(LeaveDocument, {
-    onCompleted(e) {
-      location.reload()
-    },
-    onError(error) {
-      console.error(error)
+  const [leave] = useMutation<LeaveMutation, LeaveMutationVariables>(
+    LeaveDocument,
+    {
+      onCompleted(e) {
+        location.reload()
+      },
+      onError(error) {
+        console.error(error)
+      }
     }
-  })
+  )
 
   const confirmToLeave = () => {
     if (confirm('この操作は取り消せません。本当に退出しますか？')) {
@@ -144,7 +152,7 @@ const LeaveButton = () => {
           input: {
             gameId: game.id
           }
-        } as LeaveMutationVariables
+        }
       })
     }
   }
@@ -241,15 +249,18 @@ const FollowButton = ({
 }: FollowButtonProps) => {
   const game = useGameValue()
   const [myself, refetchMyself] = useMyself(game.id)
-  const [follow] = useMutation<FollowMutation>(FollowDocument, {
-    onCompleted(e) {
-      refetchMyself()
-      refetchProfile()
-    },
-    onError(error) {
-      console.error(error)
+  const [follow] = useMutation<FollowMutation, FollowMutationVariables>(
+    FollowDocument,
+    {
+      onCompleted(e) {
+        refetchMyself()
+        refetchProfile()
+      },
+      onError(error) {
+        console.error(error)
+      }
     }
-  })
+  )
 
   const handleFollow = useCallback(() => {
     follow({
@@ -258,7 +269,7 @@ const FollowButton = ({
           gameId: game.id,
           targetGameParticipantId: participantId
         }
-      } as FollowMutationVariables
+      }
     })
   }, [follow, game.id, participantId])
 
@@ -285,15 +296,18 @@ const UnfollowButton = ({
 }: UnfollowButtonProps) => {
   const game = useGameValue()
   const [myself, refetchMyself] = useMyself(game.id)
-  const [unfollow] = useMutation<UnfollowMutation>(UnfollowDocument, {
-    onCompleted(e) {
-      refetchMyself()
-      refetchProfile()
-    },
-    onError(error) {
-      console.error(error)
+  const [unfollow] = useMutation<UnfollowMutation, UnfollowMutationVariables>(
+    UnfollowDocument,
+    {
+      onCompleted(e) {
+        refetchMyself()
+        refetchProfile()
+      },
+      onError(error) {
+        console.error(error)
+      }
     }
-  })
+  )
 
   const handleUnfollow = useCallback(() => {
     unfollow({
@@ -302,7 +316,7 @@ const UnfollowButton = ({
           gameId: game.id,
           targetGameParticipantId: participantId
         }
-      } as UnfollowMutationVariables
+      }
     })
   }, [unfollow, game.id, participantId])
 

--- a/frontend/src/components/pages/games/sidebar/game-master-edit.tsx
+++ b/frontend/src/components/pages/games/sidebar/game-master-edit.tsx
@@ -1,14 +1,12 @@
 import DangerButton from '@/components/button/danger-button'
 import PrimaryButton from '@/components/button/primary-button'
 import {
-  DeleteGameMaster,
   DeleteGameMasterDocument,
   DeleteGameMasterMutation,
   DeleteGameMasterMutationVariables,
-  NewGameMaster,
-  Player,
   QPlayersDocument,
   QPlayersQuery,
+  QPlayersQueryVariables,
   RegisterGameMasterDocument,
   RegisterGameMasterMutation,
   RegisterGameMasterMutationVariables
@@ -25,12 +23,14 @@ type Props = {
 export default function GameMasterEdit({ close }: Props) {
   const game = useGameValue()
   const router = useRouter()
-  const [deleteGameMaster] = useMutation<DeleteGameMasterMutation>(
-    DeleteGameMasterDocument
-  )
-  const [registerGameMaster] = useMutation<RegisterGameMasterMutation>(
-    RegisterGameMasterDocument
-  )
+  const [deleteGameMaster] = useMutation<
+    DeleteGameMasterMutation,
+    DeleteGameMasterMutationVariables
+  >(DeleteGameMasterDocument)
+  const [registerGameMaster] = useMutation<
+    RegisterGameMasterMutation,
+    RegisterGameMasterMutationVariables
+  >(RegisterGameMasterDocument)
 
   const handleRegister = async (id: string) => {
     if (!window.confirm('本当にゲームマスターを追加してよろしいですか？'))
@@ -42,8 +42,8 @@ export default function GameMasterEdit({ close }: Props) {
           gameId: game.id,
           playerId: id,
           isProducer: false
-        } as NewGameMaster
-      } as RegisterGameMasterMutationVariables
+        }
+      }
     })
     router.reload()
   }
@@ -57,15 +57,17 @@ export default function GameMasterEdit({ close }: Props) {
         input: {
           gameId: game.id,
           id
-        } as DeleteGameMaster
-      } as DeleteGameMasterMutationVariables
+        }
+      }
     })
     router.reload()
   }
 
-  const [players, setPlayers] = useState([] as Player[])
+  const [players, setPlayers] = useState<QPlayersQuery['players']>([])
   const [playerName, setPlayerName] = useState('')
-  const [fetchPlayers] = useLazyQuery<QPlayersQuery>(QPlayersDocument)
+  const [fetchPlayers] = useLazyQuery<QPlayersQuery, QPlayersQueryVariables>(
+    QPlayersDocument
+  )
   const refetchPlayers = async () => {
     if (playerName.length <= 1) return
     const { data } = await fetchPlayers({
@@ -76,7 +78,7 @@ export default function GameMasterEdit({ close }: Props) {
       }
     })
     if (data?.players == null) return
-    setPlayers(data.players as Player[])
+    setPlayers(data.players)
   }
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {

--- a/frontend/src/components/pages/games/sidebar/game-settings-edit.tsx
+++ b/frontend/src/components/pages/games/sidebar/game-settings-edit.tsx
@@ -1,9 +1,8 @@
 import {
+  UpdateGameLabel,
   UpdateGameSettingsMutation,
   UpdateGameSettingsDocument,
-  UpdateGameSetting,
-  UpdateGameSettingsMutationVariables,
-  GameLabel
+  UpdateGameSettingsMutationVariables
 } from '@/lib/generated/graphql'
 import { useMutation } from '@apollo/client'
 import dayjs from '@/lib/dayjs'
@@ -18,7 +17,7 @@ import { useGameValue } from '../game-hook'
 export default function GameSettingsEdit() {
   const game = useGameValue()
 
-  const defaultValues = {
+  const defaultValues: GameFormInput = {
     name: game.name,
     openAt: dayjs(game.settings.time.openAt).format('YYYY-MM-DDTHH:mm'),
     startParticipateAt: dayjs(game.settings.time.startParticipateAt).format(
@@ -46,7 +45,7 @@ export default function GameSettingsEdit() {
     periodIntervalMinutes: (game.settings.time.periodIntervalSeconds / 60) % 60,
     introduction: game.settings.background.introduction || '',
     password: ''
-  } as GameFormInput
+  }
 
   const [target, setTarget] = useState(
     game.labels.find((l) => ['誰歓', '身内'].includes(l.name))?.name ?? ''
@@ -63,29 +62,29 @@ export default function GameSettingsEdit() {
   )
   const [catchImageFiles, setCatchImageFiles] = useState<File[]>([])
 
-  const [updateGameSettings] = useMutation<UpdateGameSettingsMutation>(
-    UpdateGameSettingsDocument,
-    {
-      onError(error) {
-        console.error(error)
-      }
+  const [updateGameSettings] = useMutation<
+    UpdateGameSettingsMutation,
+    UpdateGameSettingsMutationVariables
+  >(UpdateGameSettingsDocument, {
+    onError(error) {
+      console.error(error)
     }
-  )
+  })
   const router = useRouter()
   const onSubmit: SubmitHandler<GameFormInput> = useCallback(
     async (data) => {
-      const labels: Array<GameLabel> = []
+      const labels: Array<UpdateGameLabel> = []
       if (target !== '') {
         labels.push({
           name: target,
           type: 'success'
-        } as GameLabel)
+        })
       }
       if (rating !== '全年齢') {
         labels.push({
           name: rating,
           type: 'danger'
-        } as GameLabel)
+        })
       }
 
       await updateGameSettings({
@@ -138,8 +137,8 @@ export default function GameSettingsEdit() {
                 password: data.password.length > 0 ? data.password : null
               }
             }
-          } as UpdateGameSetting
-        } as UpdateGameSettingsMutationVariables
+          }
+        }
       })
       router.reload()
     },

--- a/frontend/src/components/pages/games/sidebar/game-status-edit.tsx
+++ b/frontend/src/components/pages/games/sidebar/game-status-edit.tsx
@@ -1,17 +1,13 @@
 import {
-  Game,
   GameStatus,
   UpdatePeriodMutation,
   UpdatePeriodDocument,
   UpdatePeriodMutationVariables,
-  UpdateGamePeriod,
   UpdateStatusDocument,
   UpdateStatusMutation,
-  UpdateGameStatus,
   UpdateStatusMutationVariables,
   DeletePeriodDocument,
   DeletePeriodMutation,
-  DeleteGamePeriod,
   DeletePeriodMutationVariables
 } from '@/lib/generated/graphql'
 import { useMutation } from '@apollo/client'
@@ -61,7 +57,10 @@ const UpdateGameStatusForm = () => {
     value: gs[0]
   }))
 
-  const [updateStatus] = useMutation<UpdateStatusMutation>(UpdateStatusDocument)
+  const [updateStatus] = useMutation<
+    UpdateStatusMutation,
+    UpdateStatusMutationVariables
+  >(UpdateStatusDocument)
   const router = useRouter()
   const handleSubmit = useCallback(
     async (e: React.FormEvent) => {
@@ -71,8 +70,8 @@ const UpdateGameStatusForm = () => {
           input: {
             gameId: game.id,
             status: gameStatus
-          } as UpdateGameStatus
-        } as UpdateStatusMutationVariables
+          }
+        }
       })
       router.reload()
     },
@@ -112,7 +111,7 @@ const UpdateGamePeriodForm = () => {
       endAt: dayjs(game.periods[game.periods.length - 1].endAt).format(
         'YYYY-MM-DDTHH:mm'
       )
-    } as UpdatePeriodFormInput
+    }
   })
 
   const candidates = game.periods.map((p) => ({
@@ -133,7 +132,10 @@ const UpdateGamePeriodForm = () => {
     )
   }
 
-  const [updatePeriod] = useMutation<UpdatePeriodMutation>(UpdatePeriodDocument)
+  const [updatePeriod] = useMutation<
+    UpdatePeriodMutation,
+    UpdatePeriodMutationVariables
+  >(UpdatePeriodDocument)
   const router = useRouter()
   const onSubmit: SubmitHandler<UpdatePeriodFormInput> = useCallback(
     async (data) => {
@@ -152,8 +154,8 @@ const UpdateGamePeriodForm = () => {
                 : dayjs(
                     game.periods.find((p) => p.id === targetPeriodId)!.endAt
                   ).toDate()
-          } as UpdateGamePeriod
-        } as UpdatePeriodMutationVariables
+          }
+        }
       })
       router.reload()
     },
@@ -243,7 +245,10 @@ const DeleteGamePeriodForm = () => {
     setTargetPeriodId(id)
   }
 
-  const [deletePeriod] = useMutation<DeletePeriodMutation>(DeletePeriodDocument)
+  const [deletePeriod] = useMutation<
+    DeletePeriodMutation,
+    DeletePeriodMutationVariables
+  >(DeletePeriodDocument)
   const router = useRouter()
   const onSubmit = useCallback(async () => {
     if (!destCandidates.some((c) => c.value === destPeriodId)) {
@@ -262,8 +267,8 @@ const DeleteGamePeriodForm = () => {
           gameId: game.id,
           targetPeriodId: targetPeriodId,
           destPeriodId: destPeriodId
-        } as DeleteGamePeriod
-      } as DeletePeriodMutationVariables
+        }
+      }
     })
     router.reload()
   }, [

--- a/frontend/src/components/pages/games/sidebar/participate.tsx
+++ b/frontend/src/components/pages/games/sidebar/participate.tsx
@@ -4,8 +4,6 @@ import Modal from '@/components/modal/modal'
 import {
   Chara,
   Charachip,
-  Game,
-  NewGameParticipant,
   RegisterGameParticipantDocument,
   RegisterGameParticipantMutation,
   RegisterGameParticipantMutationVariables
@@ -42,9 +40,10 @@ export default function Participate({ close }: Props) {
   })
   const [checkedTerm, setCheckedTerm] = useState(false)
   const [checkedPolicy, setCheckedPolicy] = useState(false)
-  const [participate] = useMutation<RegisterGameParticipantMutation>(
-    RegisterGameParticipantDocument
-  )
+  const [participate] = useMutation<
+    RegisterGameParticipantMutation,
+    RegisterGameParticipantMutationVariables
+  >(RegisterGameParticipantDocument)
   const [bizError, setBizError] = useState<string | null>(null)
 
   const canUseCharachip = game.settings.chara.charachips.length > 0
@@ -81,8 +80,8 @@ export default function Participate({ close }: Props) {
             name: data.participantName,
             charaId: chara?.id,
             password: data.password
-          } as NewGameParticipant
-        } as RegisterGameParticipantMutationVariables
+          }
+        }
       })
       if (errors) {
         if (errors[0].extensions?.code === 'PARTICIPATE_ERROR') {

--- a/frontend/src/components/pages/games/sidebar/user-settings.tsx
+++ b/frontend/src/components/pages/games/sidebar/user-settings.tsx
@@ -3,21 +3,14 @@ import { QuestionMarkCircleIcon } from '@heroicons/react/24/outline'
 import Modal from '@/components/modal/modal'
 import { useModal } from '@/components/hooks/use-modal'
 import InputSelect from '@/components/form/input-select'
-import {
-  UserDisplaySettings,
-  UserPagingSettings,
-  useUserDisplaySettings,
-  useUserPagingSettings
-} from '../user-settings'
+import { useUserDisplaySettings, useUserPagingSettings } from '../user-settings'
 import PrimaryButton from '@/components/button/primary-button'
 import RadioGroup from '@/components/form/radio-group'
 import { useRouter } from 'next/router'
 import {
-  GameParticipantSetting,
   GameParticipantSettingDocument,
   GameParticipantSettingQuery,
   GameParticipantSettingQueryVariables,
-  UpdateGameParticipantSetting,
   UpdateGameParticipantSettingDocument,
   UpdateGameParticipantSettingMutation,
   UpdateGameParticipantSettingMutationVariables
@@ -76,7 +69,7 @@ const PagingSettings = () => {
     setUserPagingSettings({
       pageSize: pageSize,
       isDesc: order === 'desc'
-    } as UserPagingSettings)
+    })
     router.reload()
   }
   return (
@@ -123,7 +116,7 @@ const DisplaySettings = () => {
     setUserDisplaySettings({
       themeName: themeName,
       iconSizeRatio: iconSizeRatio
-    } as UserDisplaySettings)
+    })
     router.reload()
   }
   const candidates = [
@@ -199,18 +192,19 @@ const NotificationSettings = () => {
         keyword: ''
       }
     })
-  const [fetchSetting] = useLazyQuery<GameParticipantSettingQuery>(
-    GameParticipantSettingDocument
-  )
+  const [fetchSetting] = useLazyQuery<
+    GameParticipantSettingQuery,
+    GameParticipantSettingQueryVariables
+  >(GameParticipantSettingDocument)
   useEffect(() => {
     const fetch = async () => {
       const { data } = await fetchSetting({
         variables: {
           gameId: game.id
-        } as GameParticipantSettingQueryVariables
+        }
       })
       if (data?.gameParticipantSetting) {
-        const setting = data.gameParticipantSetting as GameParticipantSetting
+        const setting = data.gameParticipantSetting
         setValue('webhookUrl', setting.notification?.discordWebhookUrl || '')
         setValue(
           'shouldNotifyGameStart',
@@ -239,9 +233,10 @@ const NotificationSettings = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
-  const [update] = useMutation<UpdateGameParticipantSettingMutation>(
-    UpdateGameParticipantSettingDocument
-  )
+  const [update] = useMutation<
+    UpdateGameParticipantSettingMutation,
+    UpdateGameParticipantSettingMutationVariables
+  >(UpdateGameParticipantSettingDocument)
   const router = useRouter()
   const onSubmit: SubmitHandler<NotificationFormInput> = useCallback(
     async (data) => {
@@ -265,8 +260,8 @@ const NotificationSettings = () => {
                   .filter((k) => k !== '')
               }
             }
-          } as UpdateGameParticipantSetting
-        } as UpdateGameParticipantSettingMutationVariables
+          }
+        }
       })
       router.reload()
     },

--- a/frontend/src/components/pages/games/talk/talk-description.tsx
+++ b/frontend/src/components/pages/games/talk/talk-description.tsx
@@ -76,13 +76,15 @@ const TalkDescription = (props: Props) => {
         replyToMessageId: null,
         text: data.talkMessage,
         isConvertDisabled: false // TODO
-      } as NewMessage
+      }
     },
     [game.id]
   )
 
   // 発言プレビュー
-  const [talkDryRun] = useMutation<TalkDryRunMutation>(TalkDryRunDocument)
+  const [talkDryRun] = useMutation<TalkDryRunMutation, TalkMutationVariables>(
+    TalkDryRunDocument
+  )
   const [dryRunMessage, setDryRunMessage] = useState<NewMessage | null>(null)
   const [preview, setPreview] = useState<Message | null>(null)
   const onSubmitPreview: SubmitHandler<FormInput> = useCallback(
@@ -91,7 +93,7 @@ const TalkDescription = (props: Props) => {
       const { data: previewData } = await talkDryRun({
         variables: {
           input: mes
-        } as TalkMutationVariables
+        }
       })
       if (previewData?.registerMessageDryRun == null) return
       setPreview(previewData.registerMessageDryRun.message as Message)
@@ -196,16 +198,19 @@ const DescriptionPreview = (props: PreviewProps) => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
-  const [talk] = useMutation<TalkMutation>(TalkDocument, {
-    onCompleted() {
-      props.handleCompleted()
+  const [talk] = useMutation<TalkMutation, TalkMutationVariables>(
+    TalkDocument,
+    {
+      onCompleted() {
+        props.handleCompleted()
+      }
     }
-  })
+  )
   const doTalk = async () => {
     talk({
       variables: {
         input: props.dryRunMessage!
-      } as TalkMutationVariables
+      }
     })
   }
   return (

--- a/frontend/src/components/pages/games/talk/talk-description.tsx
+++ b/frontend/src/components/pages/games/talk/talk-description.tsx
@@ -5,6 +5,7 @@ import {
   TalkDocument,
   TalkDryRunDocument,
   TalkDryRunMutation,
+  TalkDryRunMutationVariables,
   TalkMutation,
   TalkMutationVariables
 } from '@/lib/generated/graphql'
@@ -82,9 +83,10 @@ const TalkDescription = (props: Props) => {
   )
 
   // 発言プレビュー
-  const [talkDryRun] = useMutation<TalkDryRunMutation, TalkMutationVariables>(
-    TalkDryRunDocument
-  )
+  const [talkDryRun] = useMutation<
+    TalkDryRunMutation,
+    TalkDryRunMutationVariables
+  >(TalkDryRunDocument)
   const [dryRunMessage, setDryRunMessage] = useState<NewMessage | null>(null)
   const [preview, setPreview] = useState<Message | null>(null)
   const onSubmitPreview: SubmitHandler<FormInput> = useCallback(

--- a/frontend/src/components/pages/games/talk/talk-direct.tsx
+++ b/frontend/src/components/pages/games/talk/talk-direct.tsx
@@ -2,21 +2,15 @@ import Image from 'next/image'
 import {
   DirectMessage,
   GameParticipantGroup,
-  GameParticipantIcon,
-  IconsDocument,
-  IconsQuery,
   MessageType,
   NewDirectMessage,
   TalkDirectDocument,
   TalkDirectDryRunDocument,
   TalkDirectDryRunMutation,
   TalkDirectMutation,
-  TalkDirectMutationVariables,
-  TalkDocument,
-  TalkMutation,
-  TalkMutationVariables
+  TalkDirectMutationVariables
 } from '@/lib/generated/graphql'
-import { useLazyQuery, useMutation } from '@apollo/client'
+import { useMutation } from '@apollo/client'
 import { useCallback, useEffect, useState } from 'react'
 import { SubmitHandler, useForm } from 'react-hook-form'
 import InputTextarea from '@/components/form/input-textarea'
@@ -106,7 +100,7 @@ const TalkDirect = (props: Props) => {
         name: data.name,
         text: data.talkMessage,
         isConvertDisabled: isConvertDisabled
-      } as NewDirectMessage
+      }
     },
     [game.id, gameParticipantGroup.id, iconId, isConvertDisabled]
   )
@@ -114,16 +108,17 @@ const TalkDirect = (props: Props) => {
     null
   )
   const [preview, setPreview] = useState<DirectMessage | null>(null)
-  const [talkDirectDryRun] = useMutation<TalkDirectDryRunMutation>(
-    TalkDirectDryRunDocument
-  )
+  const [talkDirectDryRun] = useMutation<
+    TalkDirectDryRunMutation,
+    TalkDirectMutationVariables
+  >(TalkDirectDryRunDocument)
   const onSubmitPreview: SubmitHandler<FormInput> = useCallback(
     async (data) => {
       const dm = createNewDirectMessage(data)
       const { data: previewData } = await talkDirectDryRun({
         variables: {
           input: dm
-        } as TalkDirectMutationVariables
+        }
       })
       if (previewData?.registerDirectMessageDryRun == null) return
       setPreview(
@@ -251,7 +246,10 @@ const DirectPreview = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
-  const [talkDirect] = useMutation<TalkDirectMutation>(TalkDirectDocument, {
+  const [talkDirect] = useMutation<
+    TalkDirectMutation,
+    TalkDirectMutationVariables
+  >(TalkDirectDocument, {
     onCompleted() {
       handleCompleted()
     }
@@ -260,7 +258,7 @@ const DirectPreview = ({
     talkDirect({
       variables: {
         input: dryRunMessage!
-      } as TalkDirectMutationVariables
+      }
     })
   }
 

--- a/frontend/src/components/pages/games/talk/talk-preview.tsx
+++ b/frontend/src/components/pages/games/talk/talk-preview.tsx
@@ -47,16 +47,19 @@ export default function TalkPreview({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
-  const [talk] = useMutation<TalkMutation>(TalkDocument, {
-    onCompleted() {
-      handleCompleted()
+  const [talk] = useMutation<TalkMutation, TalkMutationVariables>(
+    TalkDocument,
+    {
+      onCompleted() {
+        handleCompleted()
+      }
     }
-  })
+  )
   const doTalk = async () => {
     talk({
       variables: {
         input: dryRunMessage!
-      } as TalkMutationVariables
+      }
     })
   }
 

--- a/frontend/src/components/pages/games/talk/talk-system.tsx
+++ b/frontend/src/components/pages/games/talk/talk-system.tsx
@@ -71,13 +71,15 @@ const TalkSystem = (props: Props) => {
         replyToMessageId: null,
         text: data.talkMessage,
         isConvertDisabled: false // TODO
-      } as NewMessage
+      }
     },
     [game.id]
   )
 
   // 発言プレビュー
-  const [talkDryRun] = useMutation<TalkDryRunMutation>(TalkDryRunDocument)
+  const [talkDryRun] = useMutation<TalkDryRunMutation, TalkMutationVariables>(
+    TalkDryRunDocument
+  )
   const [dryRunMessage, setDryRunMessage] = useState<NewMessage | null>(null)
   const [preview, setPreview] = useState<Message | null>(null)
   const onSubmitPreview: SubmitHandler<FormInput> = useCallback(
@@ -86,7 +88,7 @@ const TalkSystem = (props: Props) => {
       const { data: previewData } = await talkDryRun({
         variables: {
           input: mes
-        } as TalkMutationVariables
+        }
       })
       if (previewData?.registerMessageDryRun == null) return
       setPreview(previewData.registerMessageDryRun.message as Message)
@@ -176,16 +178,19 @@ const SystemMessagePreview = (props: PreviewProps) => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
-  const [talk] = useMutation<TalkMutation>(TalkDocument, {
-    onCompleted() {
-      props.handleCompleted()
+  const [talk] = useMutation<TalkMutation, TalkMutationVariables>(
+    TalkDocument,
+    {
+      onCompleted() {
+        props.handleCompleted()
+      }
     }
-  })
+  )
   const doTalk = async () => {
     talk({
       variables: {
         input: props.dryRunMessage!
-      } as TalkMutationVariables
+      }
     })
   }
   return (

--- a/frontend/src/components/pages/games/talk/talk-system.tsx
+++ b/frontend/src/components/pages/games/talk/talk-system.tsx
@@ -5,6 +5,7 @@ import {
   TalkDocument,
   TalkDryRunDocument,
   TalkDryRunMutation,
+  TalkDryRunMutationVariables,
   TalkMutation,
   TalkMutationVariables
 } from '@/lib/generated/graphql'
@@ -77,9 +78,10 @@ const TalkSystem = (props: Props) => {
   )
 
   // 発言プレビュー
-  const [talkDryRun] = useMutation<TalkDryRunMutation, TalkMutationVariables>(
-    TalkDryRunDocument
-  )
+  const [talkDryRun] = useMutation<
+    TalkDryRunMutation,
+    TalkDryRunMutationVariables
+  >(TalkDryRunDocument)
   const [dryRunMessage, setDryRunMessage] = useState<NewMessage | null>(null)
   const [preview, setPreview] = useState<Message | null>(null)
   const onSubmitPreview: SubmitHandler<FormInput> = useCallback(

--- a/frontend/src/components/pages/games/talk/talk.tsx
+++ b/frontend/src/components/pages/games/talk/talk.tsx
@@ -6,7 +6,7 @@ import {
   NewMessage,
   TalkDryRunDocument,
   TalkDryRunMutation,
-  TalkMutationVariables
+  TalkDryRunMutationVariables
 } from '@/lib/generated/graphql'
 import { useMutation } from '@apollo/client'
 import React, { useCallback, useEffect, useState } from 'react'
@@ -131,9 +131,10 @@ const Talk = (props: Props) => {
   )
 
   // 発言プレビュー
-  const [talkDryRun] = useMutation<TalkDryRunMutation, TalkMutationVariables>(
-    TalkDryRunDocument
-  )
+  const [talkDryRun] = useMutation<
+    TalkDryRunMutation,
+    TalkDryRunMutationVariables
+  >(TalkDryRunDocument)
   const [dryRunMessage, setDryRunMessage] = useState<NewMessage | null>(null)
   const [preview, setPreview] = useState<Message | null>(null)
   const onSubmitPreview: SubmitHandler<FormInput> = useCallback(

--- a/frontend/src/components/pages/games/talk/talk.tsx
+++ b/frontend/src/components/pages/games/talk/talk.tsx
@@ -125,13 +125,15 @@ const Talk = (props: Props) => {
         replyToMessageId: replyToMessageId,
         text: data.talkMessage.trim(),
         isConvertDisabled: isConvertDisabled
-      } as NewMessage
+      }
     },
     [game.id, replyTarget, talkType, receiver, iconId, isConvertDisabled]
   )
 
   // 発言プレビュー
-  const [talkDryRun] = useMutation<TalkDryRunMutation>(TalkDryRunDocument)
+  const [talkDryRun] = useMutation<TalkDryRunMutation, TalkMutationVariables>(
+    TalkDryRunDocument
+  )
   const [dryRunMessage, setDryRunMessage] = useState<NewMessage | null>(null)
   const [preview, setPreview] = useState<Message | null>(null)
   const onSubmitPreview: SubmitHandler<FormInput> = useCallback(
@@ -140,7 +142,7 @@ const Talk = (props: Props) => {
       const { data: previewData } = await talkDryRun({
         variables: {
           input: mes
-        } as TalkMutationVariables
+        }
       })
       if (previewData?.registerMessageDryRun == null) return
       setPreview(previewData.registerMessageDryRun.message as Message)

--- a/frontend/src/components/pages/games/thread/thread-message-area.tsx
+++ b/frontend/src/components/pages/games/thread/thread-message-area.tsx
@@ -2,9 +2,9 @@ import { GoogleAdsense } from '@/components/adsense/google-adsense'
 import {
   Game,
   Message,
-  MessagesQuery,
   ThreadMessagesDocument,
-  ThreadMessagesQuery
+  ThreadMessagesQuery,
+  ThreadMessagesQueryVariables
 } from '@/lib/generated/graphql'
 import { useState, useCallback, useMemo, useEffect } from 'react'
 import MessageComponent from '../article/message-area/message-area/messages-area/message/message'
@@ -29,9 +29,10 @@ const ThreadMessageArea = (props: Props) => {
   const game = useGameValue()
   const myself = useMyselfValue()
   const { reply } = useTalkPanel()
-  const [fetchMessages] = useLazyQuery<ThreadMessagesQuery>(
-    ThreadMessagesDocument
-  )
+  const [fetchMessages] = useLazyQuery<
+    ThreadMessagesQuery,
+    ThreadMessagesQueryVariables
+  >(ThreadMessagesDocument)
   const [userPagingSettings] = useUserPagingSettings()
 
   // messages state をここで管理
@@ -46,7 +47,7 @@ const ThreadMessageArea = (props: Props) => {
       variables: {
         gameId: game.id,
         messageId: props.messageId
-      } as MessagesQuery
+      }
     })
     if (data?.threadMessages == null) return
     let msgs = data.threadMessages as Array<Message>

--- a/frontend/src/components/pages/index/user-edit.tsx
+++ b/frontend/src/components/pages/index/user-edit.tsx
@@ -31,25 +31,25 @@ export default function UserEdit({ close, myPlayer, refetchMyPlayer }: Props) {
   })
 
   const canSubmit: boolean = formState.isValid && !formState.isSubmitting
-  const [updateProfile] = useMutation<UpdatePlayerProfileMutation>(
-    UpdatePlayerProfileDocument,
-    {
-      onCompleted(e) {
-        refetchMyPlayer()
-        close()
-      },
-      onError(error) {
-        console.error(error)
-      }
+  const [updateProfile] = useMutation<
+    UpdatePlayerProfileMutation,
+    UpdatePlayerProfileMutationVariables
+  >(UpdatePlayerProfileDocument, {
+    onCompleted(e) {
+      refetchMyPlayer()
+      close()
+    },
+    onError(error) {
+      console.error(error)
     }
-  )
+  })
   const onSubmit: SubmitHandler<FormInput> = useCallback(
     (data) => {
       updateProfile({
         variables: {
           name: data.name,
           introduction: data.introduction
-        } as UpdatePlayerProfileMutationVariables
+        }
       })
     },
     [updateProfile]

--- a/frontend/src/components/pages/index/user-info.tsx
+++ b/frontend/src/components/pages/index/user-info.tsx
@@ -8,6 +8,7 @@ import UserEdit from './user-edit'
 import { useLazyQuery } from '@apollo/client'
 import {
   MyPlayerQuery,
+  MyPlayerQueryVariables,
   MyPlayerDocument,
   Player
 } from '@/lib/generated/graphql'
@@ -18,7 +19,9 @@ export default function UserInfo() {
   const userModifyModal = useModal()
 
   const [myPlayer, setMyPlayer] = useState<Player | null>(null)
-  const [fetchMyPlayer] = useLazyQuery<MyPlayerQuery>(MyPlayerDocument)
+  const [fetchMyPlayer] = useLazyQuery<MyPlayerQuery, MyPlayerQueryVariables>(
+    MyPlayerDocument
+  )
   const refetchMyPlayer = async () => {
     const { data } = await fetchMyPlayer()
     if (data?.myPlayer == null) return

--- a/frontend/src/pages/charachips.tsx
+++ b/frontend/src/pages/charachips.tsx
@@ -5,17 +5,18 @@ import {
   CharachipDetailsQuery,
   CharachipDetailsDocument,
   CharachipDetailsQueryVariables,
-  CharachipsQuery,
   Charachip,
-  Chara,
-  PageableQuery
+  Chara
 } from '@/lib/generated/graphql'
 import Head from 'next/head'
 import { FETCH_ALL_PAGE_SIZE } from '@/lib/constants'
 
 export const getServerSideProps = async () => {
   const client = createInnerClient()
-  const { data, error } = await client.query<CharachipDetailsQuery>({
+  const { data, error } = await client.query<
+    CharachipDetailsQuery,
+    CharachipDetailsQueryVariables
+  >({
     query: CharachipDetailsDocument,
     variables: {
       query: {
@@ -24,9 +25,9 @@ export const getServerSideProps = async () => {
           pageNumber: 1,
           isDesc: false,
           isLatest: false
-        } as PageableQuery
-      } as CharachipsQuery
-    } as CharachipDetailsQueryVariables
+        }
+      }
+    }
   })
   if (error) {
     console.log(error)
@@ -48,9 +49,9 @@ export const getServerSideProps = async () => {
             return {
               ...ch,
               images: cis.filter((ci) => ci.type === 'NORMAL') // 通常画像のみ
-            } as Chara
+            }
           })
-        } as Charachip
+        }
       })
     }
   }

--- a/frontend/src/pages/charachips/[id].tsx
+++ b/frontend/src/pages/charachips/[id].tsx
@@ -17,9 +17,12 @@ export const getServerSideProps = async (
   const id = Number(context.params!.id)
   const client = createInnerClient()
   const charachipId = idToBase64(id, 'Charachip')
-  const { data: charachipData } = await client.query<CharachipDetailQuery>({
+  const { data: charachipData } = await client.query<
+    CharachipDetailQuery,
+    CharachipDetailQueryVariables
+  >({
     query: CharachipDetailDocument,
-    variables: { id: charachipId } as CharachipDetailQueryVariables
+    variables: { id: charachipId }
   })
   return {
     props: {

--- a/frontend/src/pages/create-game.tsx
+++ b/frontend/src/pages/create-game.tsx
@@ -1,15 +1,8 @@
 import {
   RegisterGameMutation,
   RegisterGameMutationVariables,
-  NewGame,
   RegisterGameDocument,
-  NewGameCapacity,
-  NewGameCharaSetting,
-  NewGamePasswordSetting,
-  NewGameRuleSetting,
-  NewGameSettings,
-  NewGameTimeSetting,
-  GameLabel
+  NewGameLabel
 } from '@/lib/generated/graphql'
 import { useMutation } from '@apollo/client'
 import dayjs from '@/lib/dayjs'
@@ -26,7 +19,7 @@ import Head from 'next/head'
 export default function CreateGame() {
   const now = dayjs()
 
-  const defaultValues = {
+  const defaultValues: GameFormInput = {
     name: '',
     openAt: now.add(7, 'day').startOf('hour').format('YYYY-MM-DDTHH:mm'),
     startParticipateAt: now
@@ -48,37 +41,37 @@ export default function CreateGame() {
     periodIntervalMinutes: 0,
     password: '',
     introduction: ''
-  } as GameFormInput
+  }
 
   const [target, setTarget] = useState('誰歓')
   const [rating, setRating] = useState('全年齢')
   const [charachipIds, setCharachipIds] = useState<string[]>([])
   const [catchImageFiles, setCatchImageFiles] = useState<File[]>([])
 
-  const [registerGame] = useMutation<RegisterGameMutation>(
-    RegisterGameDocument,
-    {
-      onError(error) {
-        console.error(error)
-      }
+  const [registerGame] = useMutation<
+    RegisterGameMutation,
+    RegisterGameMutationVariables
+  >(RegisterGameDocument, {
+    onError(error) {
+      console.error(error)
     }
-  )
+  })
 
   const router = useRouter()
   const onSubmit: SubmitHandler<GameFormInput> = useCallback(
     async (data) => {
-      const labels: Array<GameLabel> = []
+      const labels: Array<NewGameLabel> = []
       if (target !== '') {
         labels.push({
           name: target,
           type: 'success'
-        } as GameLabel)
+        })
       }
       if (rating !== '全年齢') {
         labels.push({
           name: rating,
           type: 'danger'
-        } as GameLabel)
+        })
       }
 
       const { data: resData } = await registerGame({
@@ -96,11 +89,11 @@ export default function CreateGame() {
               chara: {
                 charachipIds: charachipIds,
                 canOriginalCharacter: true
-              } as NewGameCharaSetting,
+              },
               capacity: {
                 min: data.capacityMin,
                 max: data.capacityMax
-              } as NewGameCapacity,
+              },
               time: {
                 periodPrefix:
                   data.periodPrefix.length > 0 ? data.periodPrefix : null,
@@ -115,19 +108,19 @@ export default function CreateGame() {
                 startGameAt: dayjs(data.startGameAt).toDate(),
                 epilogueGameAt: dayjs(data.epilogueGameAt).toDate(),
                 finishGameAt: dayjs(data.finishGameAt).toDate()
-              } as NewGameTimeSetting,
+              },
               rule: {
                 isGameMasterProducer: false,
                 canShorten: true,
                 canSendDirectMessage: true,
                 theme: null
-              } as NewGameRuleSetting,
+              },
               password: {
                 password: data.password.length > 0 ? data.password : null
-              } as NewGamePasswordSetting
-            } as NewGameSettings
-          } as NewGame
-        } as RegisterGameMutationVariables
+              }
+            }
+          }
+        }
       })
       const id = resData?.registerGame?.game?.id
       if (!id) {

--- a/frontend/src/pages/games.tsx
+++ b/frontend/src/pages/games.tsx
@@ -13,7 +13,10 @@ import { FETCH_ALL_PAGE_SIZE } from '@/lib/constants'
 
 export const getServerSideProps = async () => {
   const client = createInnerClient()
-  const { data, error } = await client.query<IndexGamesQuery>({
+  const { data, error } = await client.query<
+    IndexGamesQuery,
+    IndexGamesQueryVariables
+  >({
     query: IndexGamesDocument,
     variables: {
       pageSize: FETCH_ALL_PAGE_SIZE,
@@ -26,7 +29,7 @@ export const getServerSideProps = async () => {
         GameStatus.Epilogue,
         GameStatus.Finished
       ]
-    } as IndexGamesQueryVariables
+    }
   })
   if (error) {
     console.log(error)

--- a/frontend/src/pages/games/[gameId].tsx
+++ b/frontend/src/pages/games/[gameId].tsx
@@ -36,9 +36,9 @@ export const getServerSideProps = async (
   const gameId = Number(context.params!.gameId)
   const client = createInnerClient()
   const gameStringId = idToBase64(gameId, 'Game')
-  const { data: gamedata } = await client.query<GameQuery>({
+  const { data: gamedata } = await client.query<GameQuery, GameQueryVariables>({
     query: GameDocument,
-    variables: { id: gameStringId } as GameQueryVariables
+    variables: { id: gameStringId }
   })
   const game = gamedata.game as Game
   const messagesQuery = fromUrlQuery(context.query, game)

--- a/frontend/src/pages/games/[gameId]/profile/[participantId].tsx
+++ b/frontend/src/pages/games/[gameId]/profile/[participantId].tsx
@@ -12,10 +12,12 @@ import {
   GameParticipantProfile,
   GameParticipantProfileDocument,
   GameParticipantProfileQuery,
+  GameParticipantProfileQueryVariables,
   GameQuery,
   GameQueryVariables,
   IconsDocument,
   IconsQuery,
+  IconsQueryVariables,
   LeaveDocument,
   LeaveMutation,
   LeaveMutationVariables,
@@ -52,20 +54,24 @@ export const getServerSideProps = async (
   const client = createInnerClient()
   // game
   const gameStringId = idToBase64(gameId, 'Game')
-  const { data: gamedata } = await client.query<GameQuery>({
+  const { data: gamedata } = await client.query<GameQuery, GameQueryVariables>({
     query: GameDocument,
-    variables: { id: gameStringId } as GameQueryVariables
+    variables: { id: gameStringId }
   })
   // profile
   const participantStringId = idToBase64(participantId, 'GameParticipant')
-  const { data: profiledata } = await client.query<GameParticipantProfileQuery>(
-    {
-      query: GameParticipantProfileDocument,
-      variables: { participantId: participantStringId }
-    }
-  )
+  const { data: profiledata } = await client.query<
+    GameParticipantProfileQuery,
+    GameParticipantProfileQueryVariables
+  >({
+    query: GameParticipantProfileDocument,
+    variables: { participantId: participantStringId }
+  })
   // icons
-  const { data: icondata } = await client.query<IconsQuery>({
+  const { data: icondata } = await client.query<
+    IconsQuery,
+    IconsQueryVariables
+  >({
     query: IconsDocument,
     variables: { participantId: participantStringId }
   })
@@ -102,10 +108,13 @@ const GameParticipantProfilePage = ({
       game.status
     )
 
-  const [fetchProfile] = useLazyQuery<GameParticipantProfileQuery>(
-    GameParticipantProfileDocument
+  const [fetchProfile] = useLazyQuery<
+    GameParticipantProfileQuery,
+    GameParticipantProfileQueryVariables
+  >(GameParticipantProfileDocument)
+  const [fetchIcons] = useLazyQuery<IconsQuery, IconsQueryVariables>(
+    IconsDocument
   )
-  const [fetchIcons] = useLazyQuery<IconsQuery>(IconsDocument)
 
   const refetchProfile = useCallback(async () => {
     const { data } = await fetchProfile({
@@ -120,8 +129,8 @@ const GameParticipantProfilePage = ({
       variables: { participantId: profile.participantId }
     })
     if (data?.gameParticipantIcons == null) return []
-    setIcons(data.gameParticipantIcons as Array<GameParticipantIcon>)
-    return data.gameParticipantIcons as Array<GameParticipantIcon>
+    setIcons(data.gameParticipantIcons)
+    return data.gameParticipantIcons
   }
 
   return (
@@ -208,14 +217,17 @@ const ThemeCSS = () => {
 
 const LeaveButton = () => {
   const game = useGameValue()
-  const [leave] = useMutation<LeaveMutation>(LeaveDocument, {
-    onCompleted(e) {
-      location.reload()
-    },
-    onError(error) {
-      console.error(error)
+  const [leave] = useMutation<LeaveMutation, LeaveMutationVariables>(
+    LeaveDocument,
+    {
+      onCompleted(e) {
+        location.reload()
+      },
+      onError(error) {
+        console.error(error)
+      }
     }
-  })
+  )
 
   const confirmToLeave = () => {
     if (confirm('この操作は取り消せません。本当に退出しますか？')) {
@@ -224,7 +236,7 @@ const LeaveButton = () => {
           input: {
             gameId: game.id
           }
-        } as LeaveMutationVariables
+        }
       })
     }
   }
@@ -343,15 +355,18 @@ const FollowButton = ({
 }: FollowButtonProps) => {
   const game = useGameValue()
   const [myself, refetchMyself] = useMyself(game.id)
-  const [follow] = useMutation<FollowMutation>(FollowDocument, {
-    onCompleted(e) {
-      refetchMyself()
-      refetchProfile()
-    },
-    onError(error) {
-      console.error(error)
+  const [follow] = useMutation<FollowMutation, FollowMutationVariables>(
+    FollowDocument,
+    {
+      onCompleted(e) {
+        refetchMyself()
+        refetchProfile()
+      },
+      onError(error) {
+        console.error(error)
+      }
     }
-  })
+  )
 
   const handleFollow = useCallback(() => {
     follow({
@@ -360,7 +375,7 @@ const FollowButton = ({
           gameId: game.id,
           targetGameParticipantId: participantId
         }
-      } as FollowMutationVariables
+      }
     })
   }, [follow, game.id, participantId])
 
@@ -387,15 +402,18 @@ const UnfollowButton = ({
 }: UnfollowButtonProps) => {
   const game = useGameValue()
   const [myself, refetchMyself] = useMyself(game.id)
-  const [unfollow] = useMutation<UnfollowMutation>(UnfollowDocument, {
-    onCompleted(e) {
-      refetchMyself()
-      refetchProfile()
-    },
-    onError(error) {
-      console.error(error)
+  const [unfollow] = useMutation<UnfollowMutation, UnfollowMutationVariables>(
+    UnfollowDocument,
+    {
+      onCompleted(e) {
+        refetchMyself()
+        refetchProfile()
+      },
+      onError(error) {
+        console.error(error)
+      }
     }
-  })
+  )
 
   const handleUnfollow = useCallback(() => {
     unfollow({
@@ -404,7 +422,7 @@ const UnfollowButton = ({
           gameId: game.id,
           targetGameParticipantId: participantId
         }
-      } as UnfollowMutationVariables
+      }
     })
   }, [unfollow, game.id, participantId])
 

--- a/frontend/src/pages/games/[gameId]/thread/[messageId].tsx
+++ b/frontend/src/pages/games/[gameId]/thread/[messageId].tsx
@@ -9,7 +9,8 @@ import {
   GameQueryVariables,
   Message,
   ThreadMessagesDocument,
-  ThreadMessagesQuery
+  ThreadMessagesQuery,
+  ThreadMessagesQueryVariables
 } from '@/lib/generated/graphql'
 import { ReactElement } from 'react'
 import { useUserDisplaySettings } from '@/components/pages/games/user-settings'
@@ -33,13 +34,16 @@ export const getServerSideProps = async (
   const client = createInnerClient()
   // game
   const gameStringId = idToBase64(gameId, 'Game')
-  const { data: gamedata } = await client.query<GameQuery>({
+  const { data: gamedata } = await client.query<GameQuery, GameQueryVariables>({
     query: GameDocument,
-    variables: { id: gameStringId } as GameQueryVariables
+    variables: { id: gameStringId }
   })
   // thread messages
   const messageStringId = idToBase64(messageId, 'Message')
-  const { data: threadMessageData } = await client.query<ThreadMessagesQuery>({
+  const { data: threadMessageData } = await client.query<
+    ThreadMessagesQuery,
+    ThreadMessagesQueryVariables
+  >({
     query: ThreadMessagesDocument,
     variables: {
       gameId: gameStringId,

--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -22,7 +22,10 @@ import { FETCH_ALL_PAGE_SIZE } from '@/lib/constants'
 
 export const getServerSideProps = async () => {
   const client = createInnerClient()
-  const { data, error } = await client.query<IndexGamesQuery>({
+  const { data, error } = await client.query<
+    IndexGamesQuery,
+    IndexGamesQueryVariables
+  >({
     query: IndexGamesDocument,
     variables: {
       pageSize: FETCH_ALL_PAGE_SIZE,
@@ -33,7 +36,7 @@ export const getServerSideProps = async () => {
         GameStatus.Progress,
         GameStatus.Epilogue
       ]
-    } as IndexGamesQueryVariables
+    }
   })
   if (error) {
     console.log(error)


### PR DESCRIPTION
closes .issues/17-type-assertion-overuse.md

## 変更内容

`frontend/src/` 内の不要な型アサーション (`as`) を整理しました。`162` 箇所 → `48` 箇所まで削減。

### Group A: Apollo hook の variables 型推論を活用

`useLazyQuery<TQuery>(Document)` だと variables の generic が `OperationVariables` になり、`} as XxxQueryVariables` のキャストが必要でした。第 2 generic に `XxxQueryVariables` を追加することで、variables の型推論が効くようになり、キャストを削除。

```ts
// before
const [fetchMyself] = useLazyQuery<MyGameParticipantQuery>(MyGameParticipantDocument)
const { data } = await fetchMyself({
  variables: { gameId } as MyGameParticipantQueryVariables
})

// after
const [fetchMyself] = useLazyQuery<MyGameParticipantQuery, MyGameParticipantQueryVariables>(
  MyGameParticipantDocument
)
const { data } = await fetchMyself({ variables: { gameId } })
```

`useMutation` も同様に対応。同時に、ネストした input オブジェクトの `} as NewGameXxx`, `} as XxxInput` も削除。

### Group B: その他の改善

- `{} as MessageAreaRefHandle` → `useRef<MessageAreaRefHandle>(null)` 化（`article.tsx`）
- `(window as any).adsbygoogle` を `Window & { adsbygoogle: unknown[] }` に narrow（`google-adsense.tsx`）
- `useState<Charachip[]>([])` → `useState<QCharachipsQuery['charachips']>([])` で widening cast を解消（`game-edit.tsx`）
- `Array<GameLabel>` → `Array<UpdateGameLabel>` / `Array<NewGameLabel>` に変更し、mutation input 型と整合（`game-settings-edit.tsx`, `create-game.tsx`）
- 未使用の `charachipIds: string[]` を `GameFormInput` から削除（`game-edit.tsx`）

### 残した `as`（48 箇所）

以下は意図的に残しています:

| 種類 | 例 | 理由 |
| --- | --- | --- |
| `[X, Y] as const` | `return [isOpen, toggle] as const` | tuple narrowing |
| import alias | `Provider as JotaiProvider` | 別名 import |
| react-hook-form FieldError | `errors[name]?.message as string \| undefined` | `FieldError.message` は string \| FieldError 等の判別共用体で、message のみ取りたいケース |
| string→enum narrowing | `value as GameStatus`, `messageTypeString as keyof typeof MessageType` | 受け側の制約から narrow |
| `JSON.parse(str) as T` | `JSON.parse(theme) as Theme` | JSON.parse は any |
| `cloneElement(children as React.ReactElement<{ close }>, ...)` | `modal.tsx` 等 | ReactNode を cloneElement 用に narrow |
| widening cast (`data.X as Player` 等) | `setMyPlayer(data.myPlayer as Player)` | inline query 型 → global 型への widening。state/atom/props の型を inline query 型に変えると広範囲に影響するため、今回は null guard 追加のみで対応（既に null guard あり） |
| `messageQuery.paging as PageableQuery \| undefined` | paging 系 | `null \| undefined \| PageableQuery` から `null` を除外 |

widening cast はスコープ外と判断。次の Issue 候補として整理可能。

## 動作確認

- [x] `cd frontend && pnpm run lint` → エラー・警告なし
- [x] `cd frontend && pnpm run build` → 成功
- [x] 既存 E2E: `cd e2e && pnpm exec playwright test` → 4 tests 全 pass

## 関連

- Phase 2 順 1（HANDOFF.md より）。次は #15 + #24（`next.config.js` の TS 化と `ignoreDuringBuilds` 解除）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)