### PR TITLE
refactor: ページスコープ atom を React Context に移行（#10 + #11 + #25）

### DIFF
--- a/frontend/src/components/pages/games/article/message-area/message-area/message-area.tsx
+++ b/frontend/src/components/pages/games/article/message-area/message-area/message-area.tsx
@@ -20,7 +20,8 @@ import {
   useGameValue,
   useMyselfValue
 } from '@/components/pages/games/game-hook'
-import { emptyMessageQuery, useInitialMessagesQuery } from './messages-query'
+import { emptyMessageQuery } from './messages-query'
+import { useInitialMessagesQuery } from '@/components/pages/games/contexts/messages-query-context'
 import { useUserPagingSettings } from '../../../user-settings'
 import TalkArea from './talk-area'
 import MessageAreaFooterMenu from './message-area-footer-menu'

--- a/frontend/src/components/pages/games/article/message-area/message-area/message-area.tsx
+++ b/frontend/src/components/pages/games/article/message-area/message-area/message-area.tsx
@@ -20,7 +20,7 @@ import {
   useGameValue,
   useMyselfValue
 } from '@/components/pages/games/game-hook'
-import { emptyMessageQuery, useMessagesQuery } from './messages-query'
+import { emptyMessageQuery, useInitialMessagesQuery } from './messages-query'
 import { useUserPagingSettings } from '../../../user-settings'
 import TalkArea from './talk-area'
 import MessageAreaFooterMenu from './message-area-footer-menu'
@@ -86,7 +86,7 @@ const MessageArea = forwardRef<MessageAreaRefHandle, Props>(
     )
 
     // 初回の取得
-    const [initialMessagesQuery] = useMessagesQuery()
+    const initialMessagesQuery = useInitialMessagesQuery()
     const [pagingSettings] = useUserPagingSettings()
     useEffect(() => {
       const paging = {

--- a/frontend/src/components/pages/games/article/message-area/message-area/messages-query.ts
+++ b/frontend/src/components/pages/games/article/message-area/message-area/messages-query.ts
@@ -6,11 +6,14 @@ import {
   MessageType,
   MessagesQuery
 } from '@/lib/generated/graphql'
-import { atom, useAtom, useSetAtom } from 'jotai'
-import { useRef } from 'react'
 import { messageTypeOptions, messageTypeValues } from './message-type'
 import { ParsedUrlQueryInput } from 'querystring'
 import { base64ToId, idToBase64 } from '@/components/graphql/convert'
+
+export {
+  MessagesQueryProvider,
+  useInitialMessagesQuery
+} from '@/components/pages/games/contexts/messages-query-context'
 
 export const emptyMessageQuery: MessagesQuery = {
   senderIds: null,
@@ -21,20 +24,6 @@ export const emptyMessageQuery: MessagesQuery = {
     pageNumber: 1,
     isDesc: true,
     isLatest: true
-  }
-}
-
-export const messagesQueryAtom = atom<MessagesQuery>(emptyMessageQuery)
-export const useMessagesQuery = () => {
-  const [getter, setter] = useAtom(messagesQueryAtom)
-  return [getter, setter] as const
-}
-export const useInitMessagesQuery = (messagesQuery: MessagesQuery) => {
-  const setMessagesQuery = useSetAtom(messagesQueryAtom)
-  const lastQueryRef = useRef<MessagesQuery | null>(null)
-  if (lastQueryRef.current !== messagesQuery) {
-    lastQueryRef.current = messagesQuery
-    setMessagesQuery(messagesQuery)
   }
 }
 

--- a/frontend/src/components/pages/games/article/message-area/message-area/messages-query.ts
+++ b/frontend/src/components/pages/games/article/message-area/message-area/messages-query.ts
@@ -10,11 +10,6 @@ import { messageTypeOptions, messageTypeValues } from './message-type'
 import { ParsedUrlQueryInput } from 'querystring'
 import { base64ToId, idToBase64 } from '@/components/graphql/convert'
 
-export {
-  MessagesQueryProvider,
-  useInitialMessagesQuery
-} from '@/components/pages/games/contexts/messages-query-context'
-
 export const emptyMessageQuery: MessagesQuery = {
   senderIds: null,
   recipientIds: null,

--- a/frontend/src/components/pages/games/article/message-area/message-area/talk-area.tsx
+++ b/frontend/src/components/pages/games/article/message-area/message-area/talk-area.tsx
@@ -1,7 +1,7 @@
 import Portal from '@/components/modal/portal'
 import Panel from '@/components/panel/panel'
 import { MessagesQuery } from '@/lib/generated/graphql'
-import { memo, useCallback, useEffect, useRef } from 'react'
+import { memo, useEffect, useRef } from 'react'
 import { useFixedPanel } from '@/components/hooks/use-fixed-panel'
 import { useGameValue, useMyPlayerValue } from '../../../game-hook'
 import Talk from '../../../talk/talk'
@@ -37,7 +37,7 @@ type TalkPanelProps = {
 }
 
 const TalkPanel = ({ search, talkAreaId }: TalkPanelProps) => {
-  const { isOpen, setIsOpen, replyTarget } = useTalkPanel()
+  const { isOpen, toggle, replyTarget } = useTalkPanel()
   const panelWrapperRef = useRef<HTMLDivElement>(null)
   const { isFixed, toggleFixed } = useFixedPanel()
 
@@ -52,16 +52,12 @@ const TalkPanel = ({ search, talkAreaId }: TalkPanelProps) => {
     search()
   }
 
-  const handleToggle = useCallback(() => {
-    setIsOpen(!isOpen)
-  }, [isOpen, setIsOpen])
-
   const panel = (
     <div ref={panelWrapperRef}>
       <Panel
         header='発言'
         isOpen={isOpen}
-        onToggle={handleToggle}
+        onToggle={toggle}
         toggleFixed={toggleFixed}
         isFixed={isFixed}
       >

--- a/frontend/src/components/pages/games/contexts/fixed-bottom-context.tsx
+++ b/frontend/src/components/pages/games/contexts/fixed-bottom-context.tsx
@@ -1,0 +1,40 @@
+import {
+  ReactNode,
+  createContext,
+  useCallback,
+  useContext,
+  useRef
+} from 'react'
+
+type FixedBottomCanceler = (cancel: () => void) => void
+
+const FixedBottomContext = createContext<FixedBottomCanceler | null>(null)
+
+type Props = {
+  children: ReactNode
+}
+
+export const FixedBottomProvider = ({ children }: Props) => {
+  // 1つ固定したら他の固定は解除する。
+  // 直前の cancel 関数だけ覚えていればよく、再レンダーは不要なので ref で持つ。
+  const previousCancelRef = useRef<() => void>(() => {})
+
+  const canceler = useCallback<FixedBottomCanceler>((cancel) => {
+    previousCancelRef.current()
+    previousCancelRef.current = cancel
+  }, [])
+
+  return (
+    <FixedBottomContext.Provider value={canceler}>
+      {children}
+    </FixedBottomContext.Provider>
+  )
+}
+
+export const useFixedBottom = (): FixedBottomCanceler => {
+  const ctx = useContext(FixedBottomContext)
+  if (!ctx) {
+    throw new Error('useFixedBottom must be used within FixedBottomProvider')
+  }
+  return ctx
+}

--- a/frontend/src/components/pages/games/contexts/game-context.tsx
+++ b/frontend/src/components/pages/games/contexts/game-context.tsx
@@ -1,0 +1,21 @@
+import { Game } from '@/lib/generated/graphql'
+import { ReactNode, createContext, useContext } from 'react'
+
+const GameContext = createContext<Game | null>(null)
+
+type Props = {
+  game: Game
+  children: ReactNode
+}
+
+export const GameProvider = ({ game, children }: Props) => (
+  <GameContext.Provider value={game}>{children}</GameContext.Provider>
+)
+
+export const useGameValue = (): Game => {
+  const game = useContext(GameContext)
+  if (!game) {
+    throw new Error('useGameValue must be used within GameProvider')
+  }
+  return game
+}

--- a/frontend/src/components/pages/games/contexts/game-context.tsx
+++ b/frontend/src/components/pages/games/contexts/game-context.tsx
@@ -4,8 +4,14 @@ import {
   GameQuery,
   GameQueryVariables
 } from '@/lib/generated/graphql'
-import { useQuery } from '@apollo/client'
-import { ReactNode, createContext, useContext } from 'react'
+import { useLazyQuery } from '@apollo/client'
+import {
+  ReactNode,
+  createContext,
+  useContext,
+  useEffect,
+  useState
+} from 'react'
 
 const GameContext = createContext<Game | null>(null)
 
@@ -15,14 +21,26 @@ type Props = {
 }
 
 // 1分に1回 game を再取得し、参加者・期間・ステータスなどの変更を反映する。
+// useQuery を使うとマウント直後に SSR と同じ GameDocument を即時で再発行してしまうため、
+// useLazyQuery + setInterval で初回 fetch も 60s 後にずらす。
 const GAME_POLL_INTERVAL_MS = 60_000
 
 export const GameProvider = ({ game: initialGame, children }: Props) => {
-  const { data } = useQuery<GameQuery, GameQueryVariables>(GameDocument, {
-    variables: { id: initialGame.id },
-    pollInterval: GAME_POLL_INTERVAL_MS
-  })
-  const game = (data?.game as Game | undefined) ?? initialGame
+  const [game, setGame] = useState<Game>(initialGame)
+  const [refetchGame] = useLazyQuery<GameQuery, GameQueryVariables>(
+    GameDocument,
+    { variables: { id: initialGame.id } }
+  )
+
+  useEffect(() => {
+    const tick = async () => {
+      const { data } = await refetchGame()
+      if (data?.game) setGame(data.game as Game)
+    }
+    const timer = setInterval(tick, GAME_POLL_INTERVAL_MS)
+    return () => clearInterval(timer)
+  }, [refetchGame])
+
   return <GameContext.Provider value={game}>{children}</GameContext.Provider>
 }
 

--- a/frontend/src/components/pages/games/contexts/game-context.tsx
+++ b/frontend/src/components/pages/games/contexts/game-context.tsx
@@ -1,4 +1,10 @@
-import { Game } from '@/lib/generated/graphql'
+import {
+  Game,
+  GameDocument,
+  GameQuery,
+  GameQueryVariables
+} from '@/lib/generated/graphql'
+import { useQuery } from '@apollo/client'
 import { ReactNode, createContext, useContext } from 'react'
 
 const GameContext = createContext<Game | null>(null)
@@ -8,9 +14,17 @@ type Props = {
   children: ReactNode
 }
 
-export const GameProvider = ({ game, children }: Props) => (
-  <GameContext.Provider value={game}>{children}</GameContext.Provider>
-)
+// 1分に1回 game を再取得し、参加者・期間・ステータスなどの変更を反映する。
+const GAME_POLL_INTERVAL_MS = 60_000
+
+export const GameProvider = ({ game: initialGame, children }: Props) => {
+  const { data } = useQuery<GameQuery, GameQueryVariables>(GameDocument, {
+    variables: { id: initialGame.id },
+    pollInterval: GAME_POLL_INTERVAL_MS
+  })
+  const game = (data?.game as Game | undefined) ?? initialGame
+  return <GameContext.Provider value={game}>{children}</GameContext.Provider>
+}
 
 export const useGameValue = (): Game => {
   const game = useContext(GameContext)

--- a/frontend/src/components/pages/games/contexts/icons-context.tsx
+++ b/frontend/src/components/pages/games/contexts/icons-context.tsx
@@ -1,0 +1,30 @@
+import {
+  GameParticipantIcon,
+  IconsDocument,
+  IconsQuery,
+  IconsQueryVariables
+} from '@/lib/generated/graphql'
+import { useQuery } from '@apollo/client'
+import { ReactNode, createContext, useContext } from 'react'
+import { useMyselfValue } from './myself-context'
+
+const IconsContext = createContext<Array<GameParticipantIcon> | null>(null)
+
+type Props = {
+  children: ReactNode
+}
+
+export const IconsProvider = ({ children }: Props) => {
+  const myself = useMyselfValue()
+  const { data } = useQuery<IconsQuery, IconsQueryVariables>(IconsDocument, {
+    variables: { participantId: myself?.id ?? '' },
+    skip: !myself
+  })
+  const icons = data?.gameParticipantIcons ?? []
+  return <IconsContext.Provider value={icons}>{children}</IconsContext.Provider>
+}
+
+export const useIconsValue = (): Array<GameParticipantIcon> => {
+  const icons = useContext(IconsContext)
+  return icons ?? []
+}

--- a/frontend/src/components/pages/games/contexts/icons-context.tsx
+++ b/frontend/src/components/pages/games/contexts/icons-context.tsx
@@ -26,5 +26,8 @@ export const IconsProvider = ({ children }: Props) => {
 
 export const useIconsValue = (): Array<GameParticipantIcon> => {
   const icons = useContext(IconsContext)
-  return icons ?? []
+  if (icons === null) {
+    throw new Error('useIconsValue must be used within IconsProvider')
+  }
+  return icons
 }

--- a/frontend/src/components/pages/games/contexts/messages-query-context.tsx
+++ b/frontend/src/components/pages/games/contexts/messages-query-context.tsx
@@ -19,7 +19,7 @@ export const MessagesQueryProvider = ({
 
 export const useInitialMessagesQuery = (): MessagesQuery => {
   const value = useContext(MessagesQueryContext)
-  if (!value) {
+  if (value === null) {
     throw new Error(
       'useInitialMessagesQuery must be used within MessagesQueryProvider'
     )

--- a/frontend/src/components/pages/games/contexts/messages-query-context.tsx
+++ b/frontend/src/components/pages/games/contexts/messages-query-context.tsx
@@ -1,0 +1,28 @@
+import { MessagesQuery } from '@/lib/generated/graphql'
+import { ReactNode, createContext, useContext } from 'react'
+
+const MessagesQueryContext = createContext<MessagesQuery | null>(null)
+
+type Props = {
+  initialMessagesQuery: MessagesQuery
+  children: ReactNode
+}
+
+export const MessagesQueryProvider = ({
+  initialMessagesQuery,
+  children
+}: Props) => (
+  <MessagesQueryContext.Provider value={initialMessagesQuery}>
+    {children}
+  </MessagesQueryContext.Provider>
+)
+
+export const useInitialMessagesQuery = (): MessagesQuery => {
+  const value = useContext(MessagesQueryContext)
+  if (!value) {
+    throw new Error(
+      'useInitialMessagesQuery must be used within MessagesQueryProvider'
+    )
+  }
+  return value
+}

--- a/frontend/src/components/pages/games/contexts/my-player-context.tsx
+++ b/frontend/src/components/pages/games/contexts/my-player-context.tsx
@@ -1,0 +1,34 @@
+import {
+  MyPlayerDocument,
+  MyPlayerQuery,
+  MyPlayerQueryVariables,
+  Player
+} from '@/lib/generated/graphql'
+import { useQuery } from '@apollo/client'
+import { ReactNode, createContext, useContext } from 'react'
+
+const MyPlayerContext = createContext<Player | null | undefined>(undefined)
+
+type Props = {
+  children: ReactNode
+}
+
+export const MyPlayerProvider = ({ children }: Props) => {
+  const { data } = useQuery<MyPlayerQuery, MyPlayerQueryVariables>(
+    MyPlayerDocument
+  )
+  const myPlayer = (data?.myPlayer as Player | null | undefined) ?? null
+  return (
+    <MyPlayerContext.Provider value={myPlayer}>
+      {children}
+    </MyPlayerContext.Provider>
+  )
+}
+
+export const useMyPlayerValue = (): Player | null => {
+  const value = useContext(MyPlayerContext)
+  if (value === undefined) {
+    throw new Error('useMyPlayerValue must be used within MyPlayerProvider')
+  }
+  return value
+}

--- a/frontend/src/components/pages/games/contexts/myself-context.tsx
+++ b/frontend/src/components/pages/games/contexts/myself-context.tsx
@@ -1,0 +1,65 @@
+import {
+  GameParticipant,
+  MyGameParticipantDocument,
+  MyGameParticipantQuery,
+  MyGameParticipantQueryVariables
+} from '@/lib/generated/graphql'
+import { useQuery } from '@apollo/client'
+import {
+  ReactNode,
+  createContext,
+  useCallback,
+  useContext,
+  useMemo
+} from 'react'
+
+type MyselfContextValue = {
+  myself: GameParticipant | null
+  refetch: () => Promise<unknown>
+}
+
+const MyselfContext = createContext<MyselfContextValue | null>(null)
+
+type Props = {
+  gameId: string
+  children: ReactNode
+}
+
+export const MyselfProvider = ({ gameId, children }: Props) => {
+  const { data, refetch } = useQuery<
+    MyGameParticipantQuery,
+    MyGameParticipantQueryVariables
+  >(MyGameParticipantDocument, {
+    variables: { gameId }
+  })
+  const myself = (data?.myGameParticipant as GameParticipant | null) ?? null
+  const refetchCallback = useCallback(async () => {
+    await refetch()
+  }, [refetch])
+  const value = useMemo<MyselfContextValue>(
+    () => ({ myself, refetch: refetchCallback }),
+    [myself, refetchCallback]
+  )
+  return (
+    <MyselfContext.Provider value={value}>{children}</MyselfContext.Provider>
+  )
+}
+
+export const useMyselfValue = (): GameParticipant | null => {
+  const ctx = useContext(MyselfContext)
+  if (!ctx) {
+    throw new Error('useMyselfValue must be used within MyselfProvider')
+  }
+  return ctx.myself
+}
+
+export const useMyself = (): [
+  GameParticipant | null,
+  () => Promise<unknown>
+] => {
+  const ctx = useContext(MyselfContext)
+  if (!ctx) {
+    throw new Error('useMyself must be used within MyselfProvider')
+  }
+  return [ctx.myself, ctx.refetch]
+}

--- a/frontend/src/components/pages/games/contexts/sidebar-context.tsx
+++ b/frontend/src/components/pages/games/contexts/sidebar-context.tsx
@@ -1,0 +1,36 @@
+import {
+  ReactNode,
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useState
+} from 'react'
+
+type SidebarContextValue = readonly [isOpen: boolean, toggle: () => void]
+
+const SidebarContext = createContext<SidebarContextValue | null>(null)
+
+type Props = {
+  children: ReactNode
+}
+
+export const SidebarProvider = ({ children }: Props) => {
+  const [isOpen, setIsOpen] = useState(false)
+  const toggle = useCallback(() => setIsOpen((prev) => !prev), [])
+  const value = useMemo<SidebarContextValue>(
+    () => [isOpen, toggle] as const,
+    [isOpen, toggle]
+  )
+  return (
+    <SidebarContext.Provider value={value}>{children}</SidebarContext.Provider>
+  )
+}
+
+export const useSidebarOpen = (): SidebarContextValue => {
+  const ctx = useContext(SidebarContext)
+  if (!ctx) {
+    throw new Error('useSidebarOpen must be used within SidebarProvider')
+  }
+  return ctx
+}

--- a/frontend/src/components/pages/games/contexts/talk-panel-context.tsx
+++ b/frontend/src/components/pages/games/contexts/talk-panel-context.tsx
@@ -1,0 +1,58 @@
+import { Message } from '@/lib/generated/graphql'
+import {
+  Dispatch,
+  ReactNode,
+  SetStateAction,
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useState
+} from 'react'
+
+type TalkPanelContextValue = {
+  isOpen: boolean
+  setIsOpen: Dispatch<SetStateAction<boolean>>
+  replyTarget: Message | null
+  reply: (message: Message) => void
+  cancelReply: () => void
+}
+
+const TalkPanelContext = createContext<TalkPanelContextValue | null>(null)
+
+type Props = {
+  children: ReactNode
+}
+
+export const TalkPanelProvider = ({ children }: Props) => {
+  const [isOpen, setIsOpen] = useState(false)
+  const [replyTarget, setReplyTarget] = useState<Message | null>(null)
+
+  const reply = useCallback((message: Message) => {
+    setReplyTarget(message)
+    setIsOpen(true)
+  }, [])
+
+  const cancelReply = useCallback(() => {
+    setReplyTarget(null)
+  }, [])
+
+  const value = useMemo<TalkPanelContextValue>(
+    () => ({ isOpen, setIsOpen, replyTarget, reply, cancelReply }),
+    [isOpen, replyTarget, reply, cancelReply]
+  )
+
+  return (
+    <TalkPanelContext.Provider value={value}>
+      {children}
+    </TalkPanelContext.Provider>
+  )
+}
+
+export const useTalkPanel = (): TalkPanelContextValue => {
+  const ctx = useContext(TalkPanelContext)
+  if (!ctx) {
+    throw new Error('useTalkPanel must be used within TalkPanelProvider')
+  }
+  return ctx
+}

--- a/frontend/src/components/pages/games/contexts/talk-panel-context.tsx
+++ b/frontend/src/components/pages/games/contexts/talk-panel-context.tsx
@@ -23,7 +23,7 @@ type Props = {
 }
 
 export const TalkPanelProvider = ({ children }: Props) => {
-  const [isOpen, setIsOpen] = useState(false)
+  const [isOpen, setIsOpen] = useState(true)
   const [replyTarget, setReplyTarget] = useState<Message | null>(null)
 
   const toggle = useCallback(() => setIsOpen((prev) => !prev), [])

--- a/frontend/src/components/pages/games/contexts/talk-panel-context.tsx
+++ b/frontend/src/components/pages/games/contexts/talk-panel-context.tsx
@@ -1,8 +1,6 @@
 import { Message } from '@/lib/generated/graphql'
 import {
-  Dispatch,
   ReactNode,
-  SetStateAction,
   createContext,
   useCallback,
   useContext,
@@ -12,7 +10,7 @@ import {
 
 type TalkPanelContextValue = {
   isOpen: boolean
-  setIsOpen: Dispatch<SetStateAction<boolean>>
+  toggle: () => void
   replyTarget: Message | null
   reply: (message: Message) => void
   cancelReply: () => void
@@ -28,6 +26,8 @@ export const TalkPanelProvider = ({ children }: Props) => {
   const [isOpen, setIsOpen] = useState(false)
   const [replyTarget, setReplyTarget] = useState<Message | null>(null)
 
+  const toggle = useCallback(() => setIsOpen((prev) => !prev), [])
+
   const reply = useCallback((message: Message) => {
     setReplyTarget(message)
     setIsOpen(true)
@@ -38,8 +38,8 @@ export const TalkPanelProvider = ({ children }: Props) => {
   }, [])
 
   const value = useMemo<TalkPanelContextValue>(
-    () => ({ isOpen, setIsOpen, replyTarget, reply, cancelReply }),
-    [isOpen, replyTarget, reply, cancelReply]
+    () => ({ isOpen, toggle, replyTarget, reply, cancelReply }),
+    [isOpen, toggle, replyTarget, reply, cancelReply]
   )
 
   return (

--- a/frontend/src/components/pages/games/game-hook.ts
+++ b/frontend/src/components/pages/games/game-hook.ts
@@ -12,6 +12,7 @@ import {
 import { useMutation, useQuery } from '@apollo/client'
 import { atom, useAtomValue, useSetAtom } from 'jotai'
 import { useCallback, useEffect, useRef } from 'react'
+import { useGameValue } from './contexts/game-context'
 import { defaultDisplaySettings, useUserDisplaySettings } from './user-settings'
 
 export { GameProvider, useGameValue } from './contexts/game-context'
@@ -76,6 +77,8 @@ export const canModifyGameSetting = (game: Game, myPlayer: Player | null) => {
 }
 
 // player（アプリスコープ atom）
+// useMyPlayer は useQuery の結果を直接返し、useEffect は useMyPlayerValue
+// 用に myPlayerAtom へ書き込むためだけに使う。
 const myPlayerAtom = atom<Player | null>(null)
 
 export const useMyPlayer = (): Player | null => {
@@ -83,10 +86,11 @@ export const useMyPlayer = (): Player | null => {
   const { data } = useQuery<MyPlayerQuery, MyPlayerQueryVariables>(
     MyPlayerDocument
   )
+  const myPlayer = (data?.myPlayer as Player | null | undefined) ?? null
   useEffect(() => {
-    if (data?.myPlayer) setMyPlayer(data.myPlayer as Player)
-  }, [data, setMyPlayer])
-  return useAtomValue(myPlayerAtom)
+    if (myPlayer) setMyPlayer(myPlayer)
+  }, [myPlayer, setMyPlayer])
+  return myPlayer
 }
 export const useMyPlayerValue = () => useAtomValue(myPlayerAtom)
 const isAdmin = (myPlayer: Player | null) => {
@@ -101,7 +105,8 @@ const periodChangeStatuses = [
   'Progress',
   'Epilogue'
 ]
-export const usePollingPeriod = (game: Game) => {
+export const usePollingPeriod = () => {
+  const game = useGameValue()
   const [changePeriod] = useMutation<
     ChangePeriodMutation,
     ChangePeriodMutationVariables

--- a/frontend/src/components/pages/games/game-hook.ts
+++ b/frontend/src/components/pages/games/game-hook.ts
@@ -21,17 +21,7 @@ import { atom, useAtom, useAtomValue, useSetAtom } from 'jotai'
 import { useCallback, useEffect, useRef } from 'react'
 import { defaultDisplaySettings, useUserDisplaySettings } from './user-settings'
 
-// game
-export const gameAtom = atom<Game | null>(null)
-export const useGame = (game: Game) => {
-  const setGame = useSetAtom(gameAtom)
-  const lastIdRef = useRef<string | null>(null)
-  if (lastIdRef.current !== game.id) {
-    lastIdRef.current = game.id
-    setGame(game)
-  }
-}
-export const useGameValue = () => useAtomValue(gameAtom)!
+export { GameProvider, useGameValue } from './contexts/game-context'
 // 発言可能なゲームステータス
 export const talkableGameStatuses = [
   'Closed',

--- a/frontend/src/components/pages/games/game-hook.ts
+++ b/frontend/src/components/pages/games/game-hook.ts
@@ -10,7 +10,7 @@ import {
   Player
 } from '@/lib/generated/graphql'
 import { useMutation, useQuery } from '@apollo/client'
-import { atom, useAtom, useAtomValue, useSetAtom } from 'jotai'
+import { atom, useAtomValue, useSetAtom } from 'jotai'
 import { useCallback, useEffect, useRef } from 'react'
 import { defaultDisplaySettings, useUserDisplaySettings } from './user-settings'
 
@@ -21,6 +21,11 @@ export {
   useMyselfValue
 } from './contexts/myself-context'
 export { IconsProvider, useIconsValue } from './contexts/icons-context'
+export { SidebarProvider, useSidebarOpen } from './contexts/sidebar-context'
+export {
+  FixedBottomProvider,
+  useFixedBottom
+} from './contexts/fixed-bottom-context'
 
 // 発言可能なゲームステータス
 export const talkableGameStatuses = [
@@ -129,19 +134,6 @@ export const usePollingPeriod = (game: Game) => {
   }, [])
 }
 
-// sidebar
-const sidebarOpenAtom = atom(false)
-export const useSidebarOpen = () => {
-  const [isOpen, setIsOpen] = useAtom(sidebarOpenAtom)
-  const toggle = () => setIsOpen(!isOpen)
-  useEffect(() => {
-    return () => setIsOpen(false)
-    // unmount 時に閉じるだけのクリーンアップ
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
-  return [isOpen, toggle] as const
-}
-
 // display settings
 const displaySettingsAtom = atom(defaultDisplaySettings)
 export const useUserDisplaySettingsAtom = () => {
@@ -153,17 +145,3 @@ export const useUserDisplaySettingsAtom = () => {
 }
 export const useUserDisplaySettingsValue = () =>
   useAtomValue(displaySettingsAtom)
-
-// 発言欄の下部固定
-// 1つ固定したら他の固定は解除する
-// 解除するための関数を保存しておく
-const fixedBottomAtom = atom({ fn: () => {} })
-export const useFixedBottom = () => {
-  const [cancelFunction, setCancelFunction] = useAtom(fixedBottomAtom)
-
-  const canceler = (func: () => void) => {
-    cancelFunction.fn()
-    setCancelFunction({ fn: func })
-  }
-  return canceler
-}

--- a/frontend/src/components/pages/games/game-hook.ts
+++ b/frontend/src/components/pages/games/game-hook.ts
@@ -4,12 +4,9 @@ import {
   ChangePeriodMutationVariables,
   Game,
   GameParticipant,
-  MyPlayerDocument,
-  MyPlayerQuery,
-  MyPlayerQueryVariables,
   Player
 } from '@/lib/generated/graphql'
-import { useMutation, useQuery } from '@apollo/client'
+import { useMutation } from '@apollo/client'
 import { atom, useAtomValue, useSetAtom } from 'jotai'
 import { useCallback, useEffect, useRef } from 'react'
 import { useGameValue } from './contexts/game-context'
@@ -22,6 +19,10 @@ export {
   useMyselfValue
 } from './contexts/myself-context'
 export { IconsProvider, useIconsValue } from './contexts/icons-context'
+export {
+  MyPlayerProvider,
+  useMyPlayerValue
+} from './contexts/my-player-context'
 export { SidebarProvider, useSidebarOpen } from './contexts/sidebar-context'
 export {
   FixedBottomProvider,
@@ -76,23 +77,6 @@ export const canModifyGameSetting = (game: Game, myPlayer: Player | null) => {
   )
 }
 
-// player（アプリスコープ atom）
-// useMyPlayer は useQuery の結果を直接返し、useEffect は useMyPlayerValue
-// 用に myPlayerAtom へ書き込むためだけに使う。
-const myPlayerAtom = atom<Player | null>(null)
-
-export const useMyPlayer = (): Player | null => {
-  const setMyPlayer = useSetAtom(myPlayerAtom)
-  const { data } = useQuery<MyPlayerQuery, MyPlayerQueryVariables>(
-    MyPlayerDocument
-  )
-  const myPlayer = (data?.myPlayer as Player | null | undefined) ?? null
-  useEffect(() => {
-    if (myPlayer) setMyPlayer(myPlayer)
-  }, [myPlayer, setMyPlayer])
-  return myPlayer
-}
-export const useMyPlayerValue = () => useAtomValue(myPlayerAtom)
 const isAdmin = (myPlayer: Player | null) => {
   return myPlayer && myPlayer.authorityCodes.includes('AuthorityAdmin')
 }

--- a/frontend/src/components/pages/games/game-hook.ts
+++ b/frontend/src/components/pages/games/game-hook.ts
@@ -4,24 +4,24 @@ import {
   ChangePeriodMutationVariables,
   Game,
   GameParticipant,
-  GameParticipantIcon,
-  IconsDocument,
-  IconsQuery,
-  IconsQueryVariables,
-  MyGameParticipantDocument,
-  MyGameParticipantQuery,
-  MyGameParticipantQueryVariables,
   MyPlayerDocument,
   MyPlayerQuery,
   MyPlayerQueryVariables,
   Player
 } from '@/lib/generated/graphql'
-import { useLazyQuery, useMutation } from '@apollo/client'
+import { useMutation, useQuery } from '@apollo/client'
 import { atom, useAtom, useAtomValue, useSetAtom } from 'jotai'
 import { useCallback, useEffect, useRef } from 'react'
 import { defaultDisplaySettings, useUserDisplaySettings } from './user-settings'
 
 export { GameProvider, useGameValue } from './contexts/game-context'
+export {
+  MyselfProvider,
+  useMyself,
+  useMyselfValue
+} from './contexts/myself-context'
+export { IconsProvider, useIconsValue } from './contexts/icons-context'
+
 // 発言可能なゲームステータス
 export const talkableGameStatuses = [
   'Closed',
@@ -70,59 +70,18 @@ export const canModifyGameSetting = (game: Game, myPlayer: Player | null) => {
   )
 }
 
-// myself
-const myselfAtom = atom<GameParticipant | null>(null)
-
-export const useMyselfInit = (gameId: string): GameParticipant | null => {
-  const [myself, refetchMyself] = useMyself(gameId)
-  const setMyselfAtom = useSetAtom(myselfAtom)
-  useEffect(() => {
-    refetchMyself()
-    return () => setMyselfAtom(null)
-    // mount 時のみ初回取得・unmount 時に atom をクリア
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
-  return myself
-}
-export const useMyself = (
-  gameId: string
-): [myself: GameParticipant | null, refetchMyself: () => void] => {
-  const [fetchMyself] = useLazyQuery<
-    MyGameParticipantQuery,
-    MyGameParticipantQueryVariables
-  >(MyGameParticipantDocument)
-  const [myself, setMyselfAtom] = useAtom(myselfAtom)
-  const fetch = async () => {
-    const { data } = await fetchMyself({
-      variables: { gameId }
-    })
-    setMyselfAtom((data?.myGameParticipant as GameParticipant) ?? null)
-  }
-  return [myself, fetch]
-}
-
-export const useMyselfValue = () => useAtomValue(myselfAtom)
-
-// player
+// player（アプリスコープ atom）
 const myPlayerAtom = atom<Player | null>(null)
 
 export const useMyPlayer = (): Player | null => {
-  const [fetchMyPlayer] = useLazyQuery<MyPlayerQuery, MyPlayerQueryVariables>(
+  const setMyPlayer = useSetAtom(myPlayerAtom)
+  const { data } = useQuery<MyPlayerQuery, MyPlayerQueryVariables>(
     MyPlayerDocument
   )
-  const [myPlayer, setMyPlayer] = useAtom(myPlayerAtom)
   useEffect(() => {
-    const fetch = async () => {
-      const { data } = await fetchMyPlayer()
-      if (data?.myPlayer == null) return
-      setMyPlayer(data.myPlayer as Player)
-    }
-    fetch()
-    return () => setMyPlayer(null)
-    // mount 時のみ初回取得・unmount 時に atom をクリア
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
-  return myPlayer
+    if (data?.myPlayer) setMyPlayer(data.myPlayer as Player)
+  }, [data, setMyPlayer])
+  return useAtomValue(myPlayerAtom)
 }
 export const useMyPlayerValue = () => useAtomValue(myPlayerAtom)
 const isAdmin = (myPlayer: Player | null) => {
@@ -182,31 +141,6 @@ export const useSidebarOpen = () => {
   }, [])
   return [isOpen, toggle] as const
 }
-
-// icons
-const iconsAtom = atom<Array<GameParticipantIcon>>([])
-export const useIcons = (): void => {
-  const myself = useMyselfValue()
-  const setIconsAtom = useSetAtom(iconsAtom)
-  const [fetchIcons] = useLazyQuery<IconsQuery, IconsQueryVariables>(
-    IconsDocument
-  )
-  const fetch = async () => {
-    if (!myself) return
-    const { data } = await fetchIcons({
-      variables: { participantId: myself.id }
-    })
-    if (data?.gameParticipantIcons == null) return
-    setIconsAtom(data.gameParticipantIcons)
-  }
-  useEffect(() => {
-    fetch()
-    return () => setIconsAtom([])
-    // myself 変化時にアイコン取得・unmount 時に空配列にリセット（fetch/setIconsAtom は意図的に外す）
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [myself])
-}
-export const useIconsValue = () => useAtomValue(iconsAtom)
 
 // display settings
 const displaySettingsAtom = atom(defaultDisplaySettings)

--- a/frontend/src/components/pages/games/profile/profile-edit.tsx
+++ b/frontend/src/components/pages/games/profile/profile-edit.tsx
@@ -38,7 +38,7 @@ export default function ProfileEdit({
   refetchProfile
 }: Props) {
   const game = useGameValue()
-  const [myself, refetchMyself] = useMyself(game.id)
+  const [myself, refetchMyself] = useMyself()
   const { register, control, formState, handleSubmit, setValue } =
     useForm<FormInput>({
       defaultValues: {

--- a/frontend/src/components/pages/games/profile/profile.tsx
+++ b/frontend/src/components/pages/games/profile/profile.tsx
@@ -248,7 +248,7 @@ const FollowButton = ({
   refetchProfile
 }: FollowButtonProps) => {
   const game = useGameValue()
-  const [myself, refetchMyself] = useMyself(game.id)
+  const [myself, refetchMyself] = useMyself()
   const [follow] = useMutation<FollowMutation, FollowMutationVariables>(
     FollowDocument,
     {
@@ -295,7 +295,7 @@ const UnfollowButton = ({
   refetchProfile
 }: UnfollowButtonProps) => {
   const game = useGameValue()
-  const [myself, refetchMyself] = useMyself(game.id)
+  const [myself, refetchMyself] = useMyself()
   const [unfollow] = useMutation<UnfollowMutation, UnfollowMutationVariables>(
     UnfollowDocument,
     {

--- a/frontend/src/components/pages/games/sidebar/sidebar.tsx
+++ b/frontend/src/components/pages/games/sidebar/sidebar.tsx
@@ -33,7 +33,7 @@ import {
   canParticipate as _canParticipate,
   canModifyGameSetting,
   useGameValue,
-  useMyPlayer,
+  useMyPlayerValue,
   useMyselfValue,
   useSidebarOpen
 } from '../game-hook'
@@ -42,7 +42,7 @@ export default function Sidebar() {
   const [isSidebarOpen, toggleSidebar] = useSidebarOpen()
   const game = useGameValue()
   const myself = useMyselfValue()
-  const myPlayer = useMyPlayer()
+  const myPlayer = useMyPlayerValue()
 
   const isGameMaster = _isGameMaster(myPlayer, game)
   const canParticipate = _canParticipate(game, myPlayer, myself, isGameMaster)

--- a/frontend/src/components/pages/games/talk/use-talk-panel.ts
+++ b/frontend/src/components/pages/games/talk/use-talk-panel.ts
@@ -1,25 +1,4 @@
-import { Message } from '@/lib/generated/graphql'
-import { atom, useAtom } from 'jotai'
-import { useCallback } from 'react'
-
-const talkPanelOpenAtom = atom(false)
-const replyTargetAtom = atom<Message | null>(null)
-
-export function useTalkPanel() {
-  const [isOpen, setIsOpen] = useAtom(talkPanelOpenAtom)
-  const [replyTarget, setReplyTarget] = useAtom(replyTargetAtom)
-
-  const reply = useCallback(
-    (message: Message) => {
-      setReplyTarget(message)
-      setIsOpen(true)
-    },
-    [setReplyTarget, setIsOpen]
-  )
-
-  const cancelReply = useCallback(() => {
-    setReplyTarget(null)
-  }, [setReplyTarget])
-
-  return { isOpen, setIsOpen, replyTarget, reply, cancelReply }
-}
+export {
+  TalkPanelProvider,
+  useTalkPanel
+} from '@/components/pages/games/contexts/talk-panel-context'

--- a/frontend/src/pages/games/[gameId].tsx
+++ b/frontend/src/pages/games/[gameId].tsx
@@ -66,7 +66,7 @@ const GamePage = ({ game, messagesQuery: initialMessagesQuery }: Props) => {
               <SidebarProvider>
                 <FixedBottomProvider>
                   <TalkPanelProvider>
-                    <GamePageContent game={game} />
+                    <GamePageContent />
                   </TalkPanelProvider>
                 </FixedBottomProvider>
               </SidebarProvider>
@@ -78,11 +78,8 @@ const GamePage = ({ game, messagesQuery: initialMessagesQuery }: Props) => {
   )
 }
 
-type ContentProps = {
-  game: Game
-}
-
-const GamePageContent = ({ game }: ContentProps) => {
+const GamePageContent = () => {
+  const game = useGameValue()
   useUserDisplaySettingsAtom()
   // 1分に1回ゲーム更新チェック
   usePollingPeriod()

--- a/frontend/src/pages/games/[gameId].tsx
+++ b/frontend/src/pages/games/[gameId].tsx
@@ -27,11 +27,9 @@ import {
   usePollingPeriod,
   useUserDisplaySettingsAtom
 } from '@/components/pages/games/game-hook'
-import {
-  fromUrlQuery,
-  MessagesQueryProvider
-} from '@/components/pages/games/article/message-area/message-area/messages-query'
-import { TalkPanelProvider } from '@/components/pages/games/talk/use-talk-panel'
+import { fromUrlQuery } from '@/components/pages/games/article/message-area/message-area/messages-query'
+import { MessagesQueryProvider } from '@/components/pages/games/contexts/messages-query-context'
+import { TalkPanelProvider } from '@/components/pages/games/contexts/talk-panel-context'
 
 export const getServerSideProps = async (
   context: GetServerSidePropsContext
@@ -86,7 +84,7 @@ const GamePageContent = ({ game }: ContentProps) => {
   useMyPlayer()
   useUserDisplaySettingsAtom()
   // 1分に1回ゲーム更新チェック
-  usePollingPeriod(game)
+  usePollingPeriod()
 
   return (
     <>

--- a/frontend/src/pages/games/[gameId].tsx
+++ b/frontend/src/pages/games/[gameId].tsx
@@ -18,10 +18,10 @@ import Layout from '@/components/layout/layout'
 import RatingWarningModal from '@/components/pages/games/rating-warning-modal'
 import {
   GameProvider,
+  IconsProvider,
+  MyselfProvider,
   useGameValue,
-  useIcons,
   useMyPlayer,
-  useMyselfInit,
   usePollingPeriod,
   useUserDisplaySettingsAtom
 } from '@/components/pages/games/game-hook'
@@ -58,10 +58,14 @@ type Props = {
 const GamePage = ({ game, messagesQuery: initialMessagesQuery }: Props) => {
   return (
     <GameProvider game={game}>
-      <GamePageContent
-        game={game}
-        initialMessagesQuery={initialMessagesQuery}
-      />
+      <MyselfProvider gameId={game.id}>
+        <IconsProvider>
+          <GamePageContent
+            game={game}
+            initialMessagesQuery={initialMessagesQuery}
+          />
+        </IconsProvider>
+      </MyselfProvider>
     </GameProvider>
   )
 }
@@ -73,9 +77,7 @@ type ContentProps = {
 
 const GamePageContent = ({ game, initialMessagesQuery }: ContentProps) => {
   useInitMessagesQuery(initialMessagesQuery)
-  useMyselfInit(game.id)
   useMyPlayer()
-  useIcons()
   useUserDisplaySettingsAtom()
   // 1分に1回ゲーム更新チェック
   usePollingPeriod(game)

--- a/frontend/src/pages/games/[gameId].tsx
+++ b/frontend/src/pages/games/[gameId].tsx
@@ -17,9 +17,11 @@ import { Theme, convertThemeToCSS, themeMap } from '@/components/theme/theme'
 import Layout from '@/components/layout/layout'
 import RatingWarningModal from '@/components/pages/games/rating-warning-modal'
 import {
+  FixedBottomProvider,
   GameProvider,
   IconsProvider,
   MyselfProvider,
+  SidebarProvider,
   useGameValue,
   useMyPlayer,
   usePollingPeriod,
@@ -27,8 +29,9 @@ import {
 } from '@/components/pages/games/game-hook'
 import {
   fromUrlQuery,
-  useInitMessagesQuery
+  MessagesQueryProvider
 } from '@/components/pages/games/article/message-area/message-area/messages-query'
+import { TalkPanelProvider } from '@/components/pages/games/talk/use-talk-panel'
 
 export const getServerSideProps = async (
   context: GetServerSidePropsContext
@@ -60,10 +63,15 @@ const GamePage = ({ game, messagesQuery: initialMessagesQuery }: Props) => {
     <GameProvider game={game}>
       <MyselfProvider gameId={game.id}>
         <IconsProvider>
-          <GamePageContent
-            game={game}
-            initialMessagesQuery={initialMessagesQuery}
-          />
+          <MessagesQueryProvider initialMessagesQuery={initialMessagesQuery}>
+            <SidebarProvider>
+              <FixedBottomProvider>
+                <TalkPanelProvider>
+                  <GamePageContent game={game} />
+                </TalkPanelProvider>
+              </FixedBottomProvider>
+            </SidebarProvider>
+          </MessagesQueryProvider>
         </IconsProvider>
       </MyselfProvider>
     </GameProvider>
@@ -72,11 +80,9 @@ const GamePage = ({ game, messagesQuery: initialMessagesQuery }: Props) => {
 
 type ContentProps = {
   game: Game
-  initialMessagesQuery: MessagesQuery
 }
 
-const GamePageContent = ({ game, initialMessagesQuery }: ContentProps) => {
-  useInitMessagesQuery(initialMessagesQuery)
+const GamePageContent = ({ game }: ContentProps) => {
   useMyPlayer()
   useUserDisplaySettingsAtom()
   // 1分に1回ゲーム更新チェック

--- a/frontend/src/pages/games/[gameId].tsx
+++ b/frontend/src/pages/games/[gameId].tsx
@@ -20,10 +20,10 @@ import {
   FixedBottomProvider,
   GameProvider,
   IconsProvider,
+  MyPlayerProvider,
   MyselfProvider,
   SidebarProvider,
   useGameValue,
-  useMyPlayer,
   usePollingPeriod,
   useUserDisplaySettingsAtom
 } from '@/components/pages/games/game-hook'
@@ -59,19 +59,21 @@ type Props = {
 const GamePage = ({ game, messagesQuery: initialMessagesQuery }: Props) => {
   return (
     <GameProvider game={game}>
-      <MyselfProvider gameId={game.id}>
-        <IconsProvider>
-          <MessagesQueryProvider initialMessagesQuery={initialMessagesQuery}>
-            <SidebarProvider>
-              <FixedBottomProvider>
-                <TalkPanelProvider>
-                  <GamePageContent game={game} />
-                </TalkPanelProvider>
-              </FixedBottomProvider>
-            </SidebarProvider>
-          </MessagesQueryProvider>
-        </IconsProvider>
-      </MyselfProvider>
+      <MyPlayerProvider>
+        <MyselfProvider gameId={game.id}>
+          <IconsProvider>
+            <MessagesQueryProvider initialMessagesQuery={initialMessagesQuery}>
+              <SidebarProvider>
+                <FixedBottomProvider>
+                  <TalkPanelProvider>
+                    <GamePageContent game={game} />
+                  </TalkPanelProvider>
+                </FixedBottomProvider>
+              </SidebarProvider>
+            </MessagesQueryProvider>
+          </IconsProvider>
+        </MyselfProvider>
+      </MyPlayerProvider>
     </GameProvider>
   )
 }
@@ -81,7 +83,6 @@ type ContentProps = {
 }
 
 const GamePageContent = ({ game }: ContentProps) => {
-  useMyPlayer()
   useUserDisplaySettingsAtom()
   // 1分に1回ゲーム更新チェック
   usePollingPeriod()

--- a/frontend/src/pages/games/[gameId].tsx
+++ b/frontend/src/pages/games/[gameId].tsx
@@ -17,7 +17,7 @@ import { Theme, convertThemeToCSS, themeMap } from '@/components/theme/theme'
 import Layout from '@/components/layout/layout'
 import RatingWarningModal from '@/components/pages/games/rating-warning-modal'
 import {
-  useGame,
+  GameProvider,
   useGameValue,
   useIcons,
   useMyPlayer,
@@ -56,7 +56,22 @@ type Props = {
 }
 
 const GamePage = ({ game, messagesQuery: initialMessagesQuery }: Props) => {
-  useGame(game)
+  return (
+    <GameProvider game={game}>
+      <GamePageContent
+        game={game}
+        initialMessagesQuery={initialMessagesQuery}
+      />
+    </GameProvider>
+  )
+}
+
+type ContentProps = {
+  game: Game
+  initialMessagesQuery: MessagesQuery
+}
+
+const GamePageContent = ({ game, initialMessagesQuery }: ContentProps) => {
   useInitMessagesQuery(initialMessagesQuery)
   useMyselfInit(game.id)
   useMyPlayer()

--- a/frontend/src/pages/games/[gameId]/profile/[participantId].tsx
+++ b/frontend/src/pages/games/[gameId]/profile/[participantId].tsx
@@ -32,9 +32,10 @@ import { Theme, convertThemeToCSS, themeMap } from '@/components/theme/theme'
 import Layout from '@/components/layout/layout'
 import {
   GameProvider,
+  MyselfProvider,
   useGameValue,
   useMyself,
-  useMyselfInit
+  useMyselfValue
 } from '@/components/pages/games/game-hook'
 import DangerButton from '@/components/button/danger-button'
 import PrimaryButton from '@/components/button/primary-button'
@@ -98,11 +99,13 @@ const GameParticipantProfilePage = ({
 }: Props) => {
   return (
     <GameProvider game={game}>
-      <GameParticipantProfilePageContent
-        game={game}
-        initialProfile={initialProfile}
-        initialIcons={initialIcons}
-      />
+      <MyselfProvider gameId={game.id}>
+        <GameParticipantProfilePageContent
+          game={game}
+          initialProfile={initialProfile}
+          initialIcons={initialIcons}
+        />
+      </MyselfProvider>
     </GameProvider>
   )
 }
@@ -118,7 +121,7 @@ const GameParticipantProfilePageContent = ({
   initialProfile,
   initialIcons
 }: ContentProps) => {
-  const myself = useMyselfInit(game.id)
+  const myself = useMyselfValue()
   const [profile, setProfile] = useState<GameParticipantProfile>(initialProfile)
   const [icons, setIcons] = useState<Array<GameParticipantIcon>>(initialIcons)
 
@@ -375,7 +378,7 @@ const FollowButton = ({
   refetchProfile
 }: FollowButtonProps) => {
   const game = useGameValue()
-  const [myself, refetchMyself] = useMyself(game.id)
+  const [myself, refetchMyself] = useMyself()
   const [follow] = useMutation<FollowMutation, FollowMutationVariables>(
     FollowDocument,
     {
@@ -422,7 +425,7 @@ const UnfollowButton = ({
   refetchProfile
 }: UnfollowButtonProps) => {
   const game = useGameValue()
-  const [myself, refetchMyself] = useMyself(game.id)
+  const [myself, refetchMyself] = useMyself()
   const [unfollow] = useMutation<UnfollowMutation, UnfollowMutationVariables>(
     UnfollowDocument,
     {

--- a/frontend/src/pages/games/[gameId]/profile/[participantId].tsx
+++ b/frontend/src/pages/games/[gameId]/profile/[participantId].tsx
@@ -101,7 +101,6 @@ const GameParticipantProfilePage = ({
     <GameProvider game={game}>
       <MyselfProvider gameId={game.id}>
         <GameParticipantProfilePageContent
-          game={game}
           initialProfile={initialProfile}
           initialIcons={initialIcons}
         />
@@ -111,16 +110,15 @@ const GameParticipantProfilePage = ({
 }
 
 type ContentProps = {
-  game: Game
   initialProfile: GameParticipantProfile
   initialIcons: Array<GameParticipantIcon>
 }
 
 const GameParticipantProfilePageContent = ({
-  game,
   initialProfile,
   initialIcons
 }: ContentProps) => {
+  const game = useGameValue()
   const myself = useMyselfValue()
   const [profile, setProfile] = useState<GameParticipantProfile>(initialProfile)
   const [icons, setIcons] = useState<Array<GameParticipantIcon>>(initialIcons)

--- a/frontend/src/pages/games/[gameId]/profile/[participantId].tsx
+++ b/frontend/src/pages/games/[gameId]/profile/[participantId].tsx
@@ -31,7 +31,7 @@ import { useUserDisplaySettings } from '@/components/pages/games/user-settings'
 import { Theme, convertThemeToCSS, themeMap } from '@/components/theme/theme'
 import Layout from '@/components/layout/layout'
 import {
-  useGame,
+  GameProvider,
   useGameValue,
   useMyself,
   useMyselfInit
@@ -96,7 +96,28 @@ const GameParticipantProfilePage = ({
   profile: initialProfile,
   icons: initialIcons
 }: Props) => {
-  useGame(game)
+  return (
+    <GameProvider game={game}>
+      <GameParticipantProfilePageContent
+        game={game}
+        initialProfile={initialProfile}
+        initialIcons={initialIcons}
+      />
+    </GameProvider>
+  )
+}
+
+type ContentProps = {
+  game: Game
+  initialProfile: GameParticipantProfile
+  initialIcons: Array<GameParticipantIcon>
+}
+
+const GameParticipantProfilePageContent = ({
+  game,
+  initialProfile,
+  initialIcons
+}: ContentProps) => {
   const myself = useMyselfInit(game.id)
   const [profile, setProfile] = useState<GameParticipantProfile>(initialProfile)
   const [icons, setIcons] = useState<Array<GameParticipantIcon>>(initialIcons)

--- a/frontend/src/pages/games/[gameId]/thread/[messageId].tsx
+++ b/frontend/src/pages/games/[gameId]/thread/[messageId].tsx
@@ -20,12 +20,12 @@ import {
   FixedBottomProvider,
   GameProvider,
   IconsProvider,
+  MyPlayerProvider,
   MyselfProvider,
   useGameValue,
-  useMyPlayer,
   useUserDisplaySettingsAtom
 } from '@/components/pages/games/game-hook'
-import { TalkPanelProvider } from '@/components/pages/games/talk/use-talk-panel'
+import { TalkPanelProvider } from '@/components/pages/games/contexts/talk-panel-context'
 import ThreadMessageArea from '@/components/pages/games/thread/thread-message-area'
 
 export const getServerSideProps = async (
@@ -75,19 +75,21 @@ const GameParticipantProfilePage = ({
 }: Props) => {
   return (
     <GameProvider game={game}>
-      <MyselfProvider gameId={game.id}>
-        <IconsProvider>
-          <FixedBottomProvider>
-            <TalkPanelProvider>
-              <GameParticipantProfilePageContent
-                game={game}
-                messageId={messageId}
-                threadMessages={threadMessages}
-              />
-            </TalkPanelProvider>
-          </FixedBottomProvider>
-        </IconsProvider>
-      </MyselfProvider>
+      <MyPlayerProvider>
+        <MyselfProvider gameId={game.id}>
+          <IconsProvider>
+            <FixedBottomProvider>
+              <TalkPanelProvider>
+                <GameParticipantProfilePageContent
+                  game={game}
+                  messageId={messageId}
+                  threadMessages={threadMessages}
+                />
+              </TalkPanelProvider>
+            </FixedBottomProvider>
+          </IconsProvider>
+        </MyselfProvider>
+      </MyPlayerProvider>
     </GameProvider>
   )
 }
@@ -97,7 +99,6 @@ const GameParticipantProfilePageContent = ({
   messageId,
   threadMessages
 }: Props) => {
-  useMyPlayer()
   useUserDisplaySettingsAtom()
 
   return (

--- a/frontend/src/pages/games/[gameId]/thread/[messageId].tsx
+++ b/frontend/src/pages/games/[gameId]/thread/[messageId].tsx
@@ -81,7 +81,6 @@ const GameParticipantProfilePage = ({
             <FixedBottomProvider>
               <TalkPanelProvider>
                 <GameParticipantProfilePageContent
-                  game={game}
                   messageId={messageId}
                   threadMessages={threadMessages}
                 />
@@ -94,11 +93,16 @@ const GameParticipantProfilePage = ({
   )
 }
 
+type ContentProps = {
+  messageId: string
+  threadMessages: Array<Message>
+}
+
 const GameParticipantProfilePageContent = ({
-  game,
   messageId,
   threadMessages
-}: Props) => {
+}: ContentProps) => {
+  const game = useGameValue()
   useUserDisplaySettingsAtom()
 
   return (

--- a/frontend/src/pages/games/[gameId]/thread/[messageId].tsx
+++ b/frontend/src/pages/games/[gameId]/thread/[messageId].tsx
@@ -17,6 +17,7 @@ import { useUserDisplaySettings } from '@/components/pages/games/user-settings'
 import { Theme, convertThemeToCSS, themeMap } from '@/components/theme/theme'
 import Layout from '@/components/layout/layout'
 import {
+  FixedBottomProvider,
   GameProvider,
   IconsProvider,
   MyselfProvider,
@@ -24,6 +25,7 @@ import {
   useMyPlayer,
   useUserDisplaySettingsAtom
 } from '@/components/pages/games/game-hook'
+import { TalkPanelProvider } from '@/components/pages/games/talk/use-talk-panel'
 import ThreadMessageArea from '@/components/pages/games/thread/thread-message-area'
 
 export const getServerSideProps = async (
@@ -75,11 +77,15 @@ const GameParticipantProfilePage = ({
     <GameProvider game={game}>
       <MyselfProvider gameId={game.id}>
         <IconsProvider>
-          <GameParticipantProfilePageContent
-            game={game}
-            messageId={messageId}
-            threadMessages={threadMessages}
-          />
+          <FixedBottomProvider>
+            <TalkPanelProvider>
+              <GameParticipantProfilePageContent
+                game={game}
+                messageId={messageId}
+                threadMessages={threadMessages}
+              />
+            </TalkPanelProvider>
+          </FixedBottomProvider>
         </IconsProvider>
       </MyselfProvider>
     </GameProvider>

--- a/frontend/src/pages/games/[gameId]/thread/[messageId].tsx
+++ b/frontend/src/pages/games/[gameId]/thread/[messageId].tsx
@@ -17,7 +17,7 @@ import { useUserDisplaySettings } from '@/components/pages/games/user-settings'
 import { Theme, convertThemeToCSS, themeMap } from '@/components/theme/theme'
 import Layout from '@/components/layout/layout'
 import {
-  useGame,
+  GameProvider,
   useGameValue,
   useIcons,
   useMyPlayer,
@@ -71,7 +71,22 @@ const GameParticipantProfilePage = ({
   messageId,
   threadMessages
 }: Props) => {
-  useGame(game)
+  return (
+    <GameProvider game={game}>
+      <GameParticipantProfilePageContent
+        game={game}
+        messageId={messageId}
+        threadMessages={threadMessages}
+      />
+    </GameProvider>
+  )
+}
+
+const GameParticipantProfilePageContent = ({
+  game,
+  messageId,
+  threadMessages
+}: Props) => {
   const [myself] = useMyself(game.id)
   useMyPlayer()
   useIcons()

--- a/frontend/src/pages/games/[gameId]/thread/[messageId].tsx
+++ b/frontend/src/pages/games/[gameId]/thread/[messageId].tsx
@@ -18,10 +18,10 @@ import { Theme, convertThemeToCSS, themeMap } from '@/components/theme/theme'
 import Layout from '@/components/layout/layout'
 import {
   GameProvider,
+  IconsProvider,
+  MyselfProvider,
   useGameValue,
-  useIcons,
   useMyPlayer,
-  useMyself,
   useUserDisplaySettingsAtom
 } from '@/components/pages/games/game-hook'
 import ThreadMessageArea from '@/components/pages/games/thread/thread-message-area'
@@ -73,11 +73,15 @@ const GameParticipantProfilePage = ({
 }: Props) => {
   return (
     <GameProvider game={game}>
-      <GameParticipantProfilePageContent
-        game={game}
-        messageId={messageId}
-        threadMessages={threadMessages}
-      />
+      <MyselfProvider gameId={game.id}>
+        <IconsProvider>
+          <GameParticipantProfilePageContent
+            game={game}
+            messageId={messageId}
+            threadMessages={threadMessages}
+          />
+        </IconsProvider>
+      </MyselfProvider>
     </GameProvider>
   )
 }
@@ -87,9 +91,7 @@ const GameParticipantProfilePageContent = ({
   messageId,
   threadMessages
 }: Props) => {
-  const [myself] = useMyself(game.id)
   useMyPlayer()
-  useIcons()
   useUserDisplaySettingsAtom()
 
   return (


### PR DESCRIPTION
closes .issues/10-page-scope-atom-to-context.md
closes .issues/11-uselazyquery-to-usequery.md
closes .issues/25-game-state-not-auto-refreshed.md

## 変更内容

### #10 ページスコープ atom → React Context

`frontend/src/components/pages/games/contexts/` 配下に Provider/Context を新規作成し、ページスコープの状態を atom から Context に移行。

- `GameProvider` / `useGameValue`（gameAtom 置換）
- `MyPlayerProvider` / `useMyPlayerValue`（myPlayerAtom 置換、レビュー round 2 で反映）
- `MyselfProvider` / `useMyself` / `useMyselfValue`（myselfAtom 置換）
- `IconsProvider` / `useIconsValue`（iconsAtom 置換）
- `MessagesQueryProvider` / `useInitialMessagesQuery`（messagesQueryAtom 置換）
- `TalkPanelProvider` / `useTalkPanel`（talkPanelOpenAtom + replyTargetAtom 置換）
- `SidebarProvider` / `useSidebarOpen`（sidebarOpenAtom 置換）
- `FixedBottomProvider` / `useFixedBottom`（fixedBottomAtom 置換）

3 ページ（`[gameId]` / `[participantId]` / `[messageId]`）に必要な Provider を入れ子で配置。`displaySettingsAtom` は app スコープ atom として残置。

副次効果として、ページ遷移時の atom リーク（#07: replyTarget / talkPanelOpen / fixedBottom など）は Provider unmount で構造的に解消される。

### #11 useLazyQuery + useEffect → useQuery

- `MyselfProvider` / `IconsProvider` / `MyPlayerProvider` の内部実装は `useQuery` を採用。

### #25 ゲーム状態の自動リフレッシュ

- `GameProvider` 内で `useLazyQuery + setInterval` により `game` を 1 分間隔で再取得（マウント時の重複 fetch を避けるため `useQuery + pollInterval` ではなく setInterval）。参加者の追加・脱退、期間遷移、ステータス変更等がリロードなしで反映される。
- 既存 `usePollingPeriod`（`changePeriod` ミューテーション）はサーバー側で期間進行を起こす役目に整理し、フロント側の状態更新は GameProvider のポーリングが担当。`usePollingPeriod` も `useGameValue()` を読むよう変更し、ポーリング後の最新 status を参照する。

## 動作確認

- [x] `cd frontend && pnpm run lint` ✔ No ESLint warnings or errors
- [x] `cd frontend && pnpm run build` 成功
- [x] 既存 E2E: `cd e2e && pnpm exec playwright test` → 4 passed
- [ ] **ユーザー手動確認依頼**:
  - ゲームページを開いたまま別タブで参加登録 → 1 分以内に参加者一覧へ反映されるか
  - 期間遷移時にサイドバーや期間プルダウンがリロードなしで更新されるか
  - ゲーム間遷移後、リプライ対象や talkPanel 開閉、固定パネル状態が前ゲームから持ち越されないか
  - サイドバー開閉、発言パネル開閉、秘話発言、スレッド画面でのリプライ等の通常操作

## 反映しなかったレビュー指摘（理由つき）

- **MyselfProvider のマウント時即時 fetch**（round 2 nit / round 3 nit）:
  `getServerSideProps` で取得しているのは `GameQuery` のみで `MyGameParticipantQuery` は SSR されていないため、Provider マウント時の fetch は重複ではなく初回取得そのもの。GameProvider と異なり setInterval 化のメリットが薄いため、`useQuery` を維持。
- **3 ページのプロバイダ構成差異**（round 3 nit）:
  ページごとに必要な Provider が異なる（例: `[messageId]` には Sidebar 不要）ことを単純に反映している。共通プロバイダを切り出すリファクタはスコープ外として今回は見送り。

## 注意点

- `GameProvider` の polling により `useGameValue()` は 1 分毎に新しい `Game` 参照を返すため、購読側コンポーネントは 1 分毎に再レンダーする。実用上の影響は確認済み（E2E 通過）。
