### PR TITLE
refactor: Talk の replyTarget 副作用を Context に集約 (#06)

### DIFF
--- a/frontend/src/components/pages/games/contexts/talk-panel-context.tsx
+++ b/frontend/src/components/pages/games/contexts/talk-panel-context.tsx
@@ -61,6 +61,11 @@ export const TalkPanelProvider = ({ children }: Props) => {
     setReceiver(sender)
     if (message.content.type === MessageType.Secret) {
       setTalkType(MessageType.Secret)
+    } else if (talkTypeRef.current === MessageType.Secret) {
+      // 秘話メッセージへの返信から通常返信に切り替えた場合、新しい
+      // 返信先に対して意図せず秘話を送らないよう Secret → TalkNormal に戻す。
+      // ユーザーが明示的に選んだ Monologue は保持する。
+      setTalkType(MessageType.TalkNormal)
     }
   }, [])
 

--- a/frontend/src/components/pages/games/contexts/talk-panel-context.tsx
+++ b/frontend/src/components/pages/games/contexts/talk-panel-context.tsx
@@ -77,6 +77,8 @@ export const TalkPanelProvider = ({ children }: Props) => {
     }
   }, [])
 
+  // 送信完了後の form 初期化用。ユーザー操作の返信解除は cancelReply を使う
+  // （cancelReply は秘話継続中の receiver 保持などの分岐を持つ）
   const resetForm = useCallback(() => {
     setReplyTarget(null)
     setReceiver(null)

--- a/frontend/src/components/pages/games/contexts/talk-panel-context.tsx
+++ b/frontend/src/components/pages/games/contexts/talk-panel-context.tsx
@@ -1,12 +1,15 @@
-import { Message } from '@/lib/generated/graphql'
+import { GameParticipant, Message, MessageType } from '@/lib/generated/graphql'
 import {
   ReactNode,
   createContext,
   useCallback,
   useContext,
+  useEffect,
   useMemo,
+  useRef,
   useState
 } from 'react'
+import { useGameValue } from './game-context'
 
 type TalkPanelContextValue = {
   isOpen: boolean
@@ -14,6 +17,11 @@ type TalkPanelContextValue = {
   replyTarget: Message | null
   reply: (message: Message) => void
   cancelReply: () => void
+  talkType: MessageType
+  setTalkType: (type: MessageType) => void
+  receiver: GameParticipant | null
+  setReceiver: (receiver: GameParticipant | null) => void
+  resetForm: () => void
 }
 
 const TalkPanelContext = createContext<TalkPanelContextValue | null>(null)
@@ -23,23 +31,76 @@ type Props = {
 }
 
 export const TalkPanelProvider = ({ children }: Props) => {
+  const game = useGameValue()
+  // game.participants は polling で頻繁に更新されるため、reply() の identity を
+  // 安定させる目的で ref 経由で参照する（消費側の不要な再レンダーを避けるため）
+  const participantsRef = useRef(game.participants)
+  useEffect(() => {
+    participantsRef.current = game.participants
+  }, [game.participants])
+
   const [isOpen, setIsOpen] = useState(true)
   const [replyTarget, setReplyTarget] = useState<Message | null>(null)
+  const [talkType, setTalkType] = useState<MessageType>(MessageType.TalkNormal)
+  const [receiver, setReceiver] = useState<GameParticipant | null>(null)
+  // cancelReply の挙動が talkType に依存するため、ref で最新値を参照する
+  const talkTypeRef = useRef(talkType)
+  useEffect(() => {
+    talkTypeRef.current = talkType
+  }, [talkType])
 
   const toggle = useCallback(() => setIsOpen((prev) => !prev), [])
 
   const reply = useCallback((message: Message) => {
     setReplyTarget(message)
     setIsOpen(true)
+    const senderId = message.sender?.participantId
+    if (senderId) {
+      const sender = participantsRef.current.find((p) => p.id === senderId)
+      if (sender) setReceiver(sender)
+    }
+    if (message.content.type === MessageType.Secret) {
+      setTalkType(MessageType.Secret)
+    }
   }, [])
 
   const cancelReply = useCallback(() => {
     setReplyTarget(null)
+    // 秘話を継続入力中であれば、返信解除しても receiver は保持する
+    if (talkTypeRef.current !== MessageType.Secret) {
+      setReceiver(null)
+    }
+  }, [])
+
+  const resetForm = useCallback(() => {
+    setReplyTarget(null)
+    setReceiver(null)
+    setTalkType(MessageType.TalkNormal)
   }, [])
 
   const value = useMemo<TalkPanelContextValue>(
-    () => ({ isOpen, toggle, replyTarget, reply, cancelReply }),
-    [isOpen, toggle, replyTarget, reply, cancelReply]
+    () => ({
+      isOpen,
+      toggle,
+      replyTarget,
+      reply,
+      cancelReply,
+      talkType,
+      setTalkType,
+      receiver,
+      setReceiver,
+      resetForm
+    }),
+    [
+      isOpen,
+      toggle,
+      replyTarget,
+      reply,
+      cancelReply,
+      talkType,
+      receiver,
+      resetForm
+    ]
   )
 
   return (

--- a/frontend/src/components/pages/games/contexts/talk-panel-context.tsx
+++ b/frontend/src/components/pages/games/contexts/talk-panel-context.tsx
@@ -55,10 +55,10 @@ export const TalkPanelProvider = ({ children }: Props) => {
     setReplyTarget(message)
     setIsOpen(true)
     const senderId = message.sender?.participantId
-    if (senderId) {
-      const sender = participantsRef.current.find((p) => p.id === senderId)
-      if (sender) setReceiver(sender)
-    }
+    const sender = senderId
+      ? participantsRef.current.find((p) => p.id === senderId) ?? null
+      : null
+    setReceiver(sender)
     if (message.content.type === MessageType.Secret) {
       setTalkType(MessageType.Secret)
     }
@@ -98,7 +98,9 @@ export const TalkPanelProvider = ({ children }: Props) => {
       reply,
       cancelReply,
       talkType,
+      setTalkType,
       receiver,
+      setReceiver,
       resetForm
     ]
   )

--- a/frontend/src/components/pages/games/talk/talk.tsx
+++ b/frontend/src/components/pages/games/talk/talk.tsx
@@ -38,7 +38,15 @@ interface FormInput {
 const Talk = (props: Props) => {
   const game = useGameValue()
   const myself = useMyselfValue()!
-  const { replyTarget, cancelReply: cancelReplyAtom } = useTalkPanel()
+  const {
+    replyTarget,
+    cancelReply,
+    talkType,
+    setTalkType,
+    receiver,
+    setReceiver,
+    resetForm
+  } = useTalkPanel()
 
   const { control, formState, handleSubmit, setValue } = useForm<FormInput>({
     defaultValues: {
@@ -48,10 +56,6 @@ const Talk = (props: Props) => {
   })
   const updateTalkMessage = (str: string) => setValue('talkMessage', str)
 
-  // 発言種別
-  const [talkType, setTalkType] = useState(MessageType.TalkNormal)
-  // 送信相手
-  const [receiver, setReceiver] = useState<GameParticipant | null>(null)
   // 選択中のアイコン
   const [iconId, setIconId] = useState<string>('')
   // 装飾やランダム変換しない
@@ -63,26 +67,10 @@ const Talk = (props: Props) => {
     setIconId(icons.length <= 0 ? '' : icons[0].id)
   }, [icons])
 
-  // replyTarget の変更に反応して receiver と talkType を設定
-  useEffect(() => {
-    if (replyTarget) {
-      setReceiver(
-        game.participants.find(
-          (p) => p.id === replyTarget.sender!.participantId
-        )!
-      )
-      if (replyTarget.content.type === MessageType.Secret) {
-        setTalkType(MessageType.Secret)
-      }
-    }
-  }, [replyTarget, game.participants])
-
   const init = () => {
-    setTalkType(MessageType.TalkNormal)
     setPreview(null)
     setDryRunMessage(null)
-    cancelReplyAtom()
-    setReceiver(null)
+    resetForm()
     setValue('name', myself.name)
     setValue('talkMessage', '')
     setIconId(icons[0].id)
@@ -151,13 +139,6 @@ const Talk = (props: Props) => {
     },
     [createNewMessage, talkDryRun]
   )
-
-  const cancelReply = () => {
-    cancelReplyAtom()
-    if (talkType !== MessageType.Secret) {
-      setReceiver(null)
-    }
-  }
 
   const talkMessageId = `${props.talkAreaId}-talk-message`
 


### PR DESCRIPTION
closes .issues/06-talk-effect-chain.md

## 変更内容
- `talk.tsx` の `replyTarget` 変更を監視する `useEffect`（receiver/talkType を同期する暗黙の連鎖）を削除
- `TalkPanelContext` に `talkType` / `receiver` の state を移動し、副作用を以下に集約:
  - `reply(message)`: `replyTarget` の設定に加え、送信者から `receiver` を導出し、秘話なら `talkType` も Secret に設定
  - `cancelReply()`: `replyTarget` をクリア。秘話継続中（talkType === Secret）であれば receiver は保持（既存挙動を維持）
  - `resetForm()`: 全ての返信関連 state をリセット（送信完了後の `init()` から呼ぶ）
- `talk.tsx` の `init()` を `resetForm()` の単一呼び出しで完結するよう簡素化
- `game.participants` ref / `talkType` ref で `reply` / `cancelReply` の identity を安定化（消費側の不要な再レンダー回避）

## 動作確認
- [x] pnpm run lint
- [x] pnpm run build
- [x] 既存 E2E: cd e2e && pnpm exec playwright test （4 passed / 32.4s）
- [ ] ユーザー手動確認依頼: 発言パネルでの返信フロー（通常/独り言/秘話の各 talkType への切替・「返信解除」ボタン・送信後の form リセット）が従来通り動作するか