### PR TITLE
refactor: forwardRef/memo に displayName を付与 (#22)

### DIFF
--- a/frontend/.eslintrc.json
+++ b/frontend/.eslintrc.json
@@ -14,7 +14,6 @@
     "plugin:tailwindcss/recommended"
   ],
   "rules": {
-    "react/display-name": "off",
     "react-hooks/exhaustive-deps": "warn",
     "@next/next/no-img-element": "off",
     "tailwindcss/no-custom-classname": ["warn", {

--- a/frontend/src/components/pages/games/article/message-area/direct-message/direct-message-area.tsx
+++ b/frontend/src/components/pages/games/article/message-area/direct-message/direct-message-area.tsx
@@ -282,6 +282,7 @@ const DirectTalkArea = memo((props: DirectTalkAreaProps) => {
     </div>
   )
 })
+DirectTalkArea.displayName = 'DirectTalkArea'
 
 const DirectTalkPanel = (props: DirectTalkAreaProps) => {
   const { group, search } = props

--- a/frontend/src/components/pages/games/article/message-area/message-area/message-area.tsx
+++ b/frontend/src/components/pages/games/article/message-area/message-area/message-area.tsx
@@ -183,5 +183,6 @@ const MessageArea = forwardRef<MessageAreaRefHandle, Props>(
     )
   }
 )
+MessageArea.displayName = 'MessageArea'
 
 export default MessageArea

--- a/frontend/src/components/pages/games/article/message-area/message-area/talk-area.tsx
+++ b/frontend/src/components/pages/games/article/message-area/message-area/talk-area.tsx
@@ -28,6 +28,7 @@ const TalkArea = memo((props: TalkAreaProps) => {
     </div>
   )
 })
+TalkArea.displayName = 'TalkArea'
 
 export default TalkArea
 

--- a/frontend/src/components/pages/games/profile/participant-icon-edit.tsx
+++ b/frontend/src/components/pages/games/profile/participant-icon-edit.tsx
@@ -247,6 +247,7 @@ const Icon = forwardRef<HTMLDivElement, IconProps>(
     )
   }
 )
+Icon.displayName = 'Icon'
 
 const IconUploadArea = ({
   refetchIcons,


### PR DESCRIPTION
## Summary

- `forwardRef` / `memo` でラップしたコンポーネント計 4 つに `displayName` を付与
  - `MessageArea` (forwardRef) — `frontend/src/components/pages/games/article/message-area/message-area/message-area.tsx`
  - `Icon` (forwardRef) — `frontend/src/components/pages/games/profile/participant-icon-edit.tsx`
  - `TalkArea` (memo) — `frontend/src/components/pages/games/article/message-area/message-area/talk-area.tsx`
  - `DirectTalkArea` (memo) — `frontend/src/components/pages/games/article/message-area/direct-message/direct-message-area.tsx`
- ESLint の `react/display-name: "off"` override を削除し、Next.js デフォルト（error）を有効化
  - `forwardRef` / `memo` の displayName 漏れを今後 lint でブロックできる

## なぜ

React DevTools で `ForwardRef` / `Memo` のように匿名表示されデバッグしにくかった。Issue #22 の対応。

## 補足

`message.tsx` の `MessageComponent` は `memo(function MessageComponent(...))` の名前付き関数式で宣言されており、関数名から displayName が解決されるため `react/display-name` ルールも満たしている。今回の付与対象には含めていない（今後アロー関数化された場合は新ルールが lint エラーで検出する）。

## Test plan

- [x] `pnpm run lint` PASS
- [x] `pnpm run build` PASS
- [x] `pnpm exec playwright test` 4/4 PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)
