### PR TITLE
refactor: Panel の controlled/uncontrolled API を discriminated union で明示 (#05)

### DIFF
--- a/frontend/src/components/panel/panel.tsx
+++ b/frontend/src/components/panel/panel.tsx
@@ -1,32 +1,37 @@
 import { useState } from 'react'
 
-type Props = {
+type BaseProps = {
   header: string
   children: React.ReactNode
-  isOpen?: boolean
-  onToggle?: () => void
   isFixed?: boolean
   toggleFixed?: (e: React.MouseEvent) => void
 }
 
-const Panel = (props: Props) => {
-  const {
-    header,
-    children,
-    isOpen: isOpenProp = true,
-    onToggle,
-    isFixed = false,
-    toggleFixed
-  } = props
+type ControlledProps = {
+  isOpen: boolean
+  onToggle: () => void
+  defaultOpen?: never
+}
 
-  // onToggle が渡された場合は controlled、そうでなければ uncontrolled
-  const [internalOpen, setInternalOpen] = useState(isOpenProp)
-  const isOpen = onToggle ? isOpenProp : internalOpen
+type UncontrolledProps = {
+  isOpen?: never
+  onToggle?: never
+  defaultOpen?: boolean
+}
+
+type Props = BaseProps & (ControlledProps | UncontrolledProps)
+
+const Panel = (props: Props) => {
+  const { header, children, isFixed = false, toggleFixed } = props
+  const isControlled = props.onToggle !== undefined
+
+  const [internalOpen, setInternalOpen] = useState(props.defaultOpen ?? true)
+  const isOpen = isControlled ? props.isOpen : internalOpen
 
   const handleClick = (e: React.MouseEvent) => {
     e.preventDefault()
-    if (onToggle) {
-      onToggle()
+    if (isControlled) {
+      props.onToggle()
     } else {
       setInternalOpen((prev) => !prev)
     }

--- a/frontend/src/components/panel/panel.tsx
+++ b/frontend/src/components/panel/panel.tsx
@@ -23,14 +23,15 @@ type Props = BaseProps & (ControlledProps | UncontrolledProps)
 
 const Panel = (props: Props) => {
   const { header, children, isFixed = false, toggleFixed } = props
-  const isControlled = props.onToggle !== undefined
 
+  // controlled 時は使われないが、Hooks の規則上常に呼ぶ必要がある
   const [internalOpen, setInternalOpen] = useState(props.defaultOpen ?? true)
-  const isOpen = isControlled ? props.isOpen : internalOpen
+
+  const isOpen = props.onToggle !== undefined ? props.isOpen : internalOpen
 
   const handleClick = (e: React.MouseEvent) => {
     e.preventDefault()
-    if (isControlled) {
+    if (props.onToggle !== undefined) {
       props.onToggle()
     } else {
       setInternalOpen((prev) => !prev)


### PR DESCRIPTION
## Summary

- `Panel` の Props を **controlled (isOpen + onToggle)** / **uncontrolled (defaultOpen)** の discriminated union に分離
- 「`isOpen` だけ」「`onToggle` だけ」のような片肺呼び出しを TypeScript レベルで禁止（`never` による narrowing）
- 内部実装は `isControlled = props.onToggle !== undefined` で分岐（従来 `onToggle` 有無で挙動を切り替えていたのを型で表現）
- 既存呼び出しは API 互換のため変更不要（uncontrolled 3 箇所、controlled 1 箇所）

## API

```ts
// controlled（親が状態管理）
<Panel isOpen={open} onToggle={toggle} ...>

// uncontrolled（初期値のみ、内部で toggle 管理）
<Panel defaultOpen={false} ...>
<Panel ...>  // defaultOpen 省略 = true（従来挙動）
```

## なぜ

旧 API は `onToggle` の有無で controlled/uncontrolled が切り替わる暗黙の仕様で、`isOpen` だけを渡すと無視される（uncontrolled 時は `useState` の初期値にしかならない）など読み手が混乱しやすかった。Issue #05。

## Test plan

- [x] `pnpm run lint` PASS
- [x] `pnpm run build` PASS
- [x] `pnpm exec playwright test` 4/4 PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)