### PR TITLE
fix: プロフィール画像/キャッチ画像の削除→更新で URL が消えないバグを修正 (#34)

### DIFF
--- a/frontend/src/components/form/input-image.tsx
+++ b/frontend/src/components/form/input-image.tsx
@@ -1,4 +1,4 @@
-import { Dispatch, SetStateAction, useRef, useState } from 'react'
+import { Dispatch, SetStateAction, useEffect, useRef, useState } from 'react'
 import DangerButton from '../button/danger-button'
 import PrimaryButton from '../button/primary-button'
 
@@ -8,11 +8,16 @@ interface Props {
   setImages: Dispatch<SetStateAction<File[]>>
   // 現在の画像 URL（既存登録 URL / アップロード直後の blob URL / 削除後の null）。
   // 親が単一ソースを管理することで「削除→更新で URL が消えない」バグを防ぐ。
+  // blob URL は InputImage 内部で createObjectURL/revokeObjectURL を行うので
+  // 呼び出し側は revoke を意識する必要なし。
   previewImageUrl: string | null
   setPreviewImageUrl: (url: string | null) => void
   maxFileKByte?: number
   disabled?: boolean
 }
+
+const isBlobUrl = (url: string | null): boolean =>
+  url !== null && url.startsWith('blob:')
 
 const allowImageTypes = [
   'image/jpeg',
@@ -33,6 +38,26 @@ export default function InputImage({
 }: Props) {
   const [errorMessage, setErrorMessage] = useState('')
   const inputRef = useRef<HTMLInputElement>(null!)
+  // この InputImage が createObjectURL で作った blob URL のみを追跡する。
+  // 親由来の既存 URL（http(s)://...）は revoke 対象外。
+  const ownedBlobUrlRef = useRef<string | null>(null)
+
+  const replaceOwnedBlobUrl = (next: string | null) => {
+    if (ownedBlobUrlRef.current !== null) {
+      URL.revokeObjectURL(ownedBlobUrlRef.current)
+    }
+    ownedBlobUrlRef.current = next
+  }
+
+  // アンマウント時にも blob URL をリークさせない
+  useEffect(() => {
+    return () => {
+      if (ownedBlobUrlRef.current !== null) {
+        URL.revokeObjectURL(ownedBlobUrlRef.current)
+        ownedBlobUrlRef.current = null
+      }
+    }
+  }, [])
 
   const onProfileButtonClick = () => {
     inputRef.current.click()
@@ -57,12 +82,17 @@ export default function InputImage({
       return
     }
 
+    const nextBlobUrl = URL.createObjectURL(file)
+    replaceOwnedBlobUrl(nextBlobUrl)
     setImages([file])
-    setPreviewImageUrl(URL.createObjectURL(file))
+    setPreviewImageUrl(nextBlobUrl)
   }
 
   const handleCancel = () => {
     setErrorMessage('')
+    if (isBlobUrl(previewImageUrl)) {
+      replaceOwnedBlobUrl(null)
+    }
     setImages([])
     setPreviewImageUrl(null)
   }

--- a/frontend/src/components/form/input-image.tsx
+++ b/frontend/src/components/form/input-image.tsx
@@ -6,7 +6,10 @@ interface Props {
   label?: string
   name: string
   setImages: Dispatch<SetStateAction<File[]>>
-  defaultImageUrl?: string | null
+  // 現在の画像 URL（既存登録 URL / アップロード直後の blob URL / 削除後の null）。
+  // 親が単一ソースを管理することで「削除→更新で URL が消えない」バグを防ぐ。
+  previewImageUrl: string | null
+  setPreviewImageUrl: (url: string | null) => void
   maxFileKByte?: number
   disabled?: boolean
 }
@@ -23,12 +26,12 @@ export default function InputImage({
   label,
   name,
   setImages,
-  defaultImageUrl,
+  previewImageUrl,
+  setPreviewImageUrl,
   maxFileKByte = 1024,
   disabled = false
 }: Props) {
   const [errorMessage, setErrorMessage] = useState('')
-  const [previewImageUrl, setPreviewImageUrl] = useState(defaultImageUrl)
   const inputRef = useRef<HTMLInputElement>(null!)
 
   const onProfileButtonClick = () => {
@@ -61,7 +64,7 @@ export default function InputImage({
   const handleCancel = () => {
     setErrorMessage('')
     setImages([])
-    setPreviewImageUrl('')
+    setPreviewImageUrl(null)
   }
 
   return (

--- a/frontend/src/components/form/input-image.tsx
+++ b/frontend/src/components/form/input-image.tsx
@@ -16,9 +16,6 @@ interface Props {
   disabled?: boolean
 }
 
-const isBlobUrl = (url: string | null): boolean =>
-  url !== null && url.startsWith('blob:')
-
 const allowImageTypes = [
   'image/jpeg',
   'image/png',
@@ -90,9 +87,8 @@ export default function InputImage({
 
   const handleCancel = () => {
     setErrorMessage('')
-    if (isBlobUrl(previewImageUrl)) {
-      replaceOwnedBlobUrl(null)
-    }
+    // ref が null の場合（親由来の既存 URL）は内部で no-op になる
+    replaceOwnedBlobUrl(null)
     setImages([])
     setPreviewImageUrl(null)
   }

--- a/frontend/src/components/pages/create-game/game-edit.tsx
+++ b/frontend/src/components/pages/create-game/game-edit.tsx
@@ -39,6 +39,7 @@ type Props = {
   theme?: string | null
   setTheme?: Dispatch<SetStateAction<string | null>>
   catchImageUrl: string | null
+  setCatchImageUrl: (url: string | null) => void
   catchImages: File[]
   setCatchImages: Dispatch<SetStateAction<File[]>>
 }
@@ -474,7 +475,8 @@ export default function GameEdit(props: Props) {
             <InputImage
               name='profileImage'
               setImages={props.setCatchImages}
-              defaultImageUrl={props.catchImageUrl}
+              previewImageUrl={props.catchImageUrl}
+              setPreviewImageUrl={props.setCatchImageUrl}
             />
           </div>
           {props.canModifyTheme == true && (

--- a/frontend/src/components/pages/games/profile/profile-edit.tsx
+++ b/frontend/src/components/pages/games/profile/profile-edit.tsx
@@ -48,6 +48,9 @@ export default function ProfileEdit({
       }
     })
   const [images, setImages] = useState<File[]>([])
+  const [profileImagePreviewUrl, setProfileImagePreviewUrl] = useState<
+    string | null
+  >(profile.profileImageUrl ?? null)
   const [iconId, setIconId] = useState<string | null>(
     myself?.profileIcon?.id ?? null
   )
@@ -76,7 +79,9 @@ export default function ProfileEdit({
             gameId: game.id,
             name: data.name,
             profileImageFile: images.length > 0 ? images[0] : null,
-            profileImageUrl: images.length > 0 ? null : profile.profileImageUrl,
+            // 新規アップロード時はファイル経由で送るので URL は null。
+            // それ以外は親が保持する preview URL（既存 URL or 削除後の null）。
+            profileImageUrl: images.length > 0 ? null : profileImagePreviewUrl,
             profileIconId: iconId,
             introduction: data.introduction,
             memo: null, // TODO: 消えてしまうかも
@@ -85,7 +90,7 @@ export default function ProfileEdit({
         }
       })
     },
-    [updateProfile, images, iconId, game.id, profile.profileImageUrl]
+    [updateProfile, images, profileImagePreviewUrl, iconId, game.id]
   )
 
   const selectedIcon = icons.find((icon) => icon.id === iconId)
@@ -149,7 +154,8 @@ export default function ProfileEdit({
           <InputImage
             name='profileImage'
             setImages={setImages}
-            defaultImageUrl={profile.profileImageUrl}
+            previewImageUrl={profileImagePreviewUrl}
+            setPreviewImageUrl={setProfileImagePreviewUrl}
             disabled={!canChangeProfileImage}
           />
         </div>

--- a/frontend/src/components/pages/games/sidebar/game-settings-edit.tsx
+++ b/frontend/src/components/pages/games/sidebar/game-settings-edit.tsx
@@ -61,6 +61,9 @@ export default function GameSettingsEdit() {
     game.settings.rule.theme ?? null
   )
   const [catchImageFiles, setCatchImageFiles] = useState<File[]>([])
+  const [catchImageUrl, setCatchImageUrl] = useState<string | null>(
+    game.settings.background.catchImageUrl ?? null
+  )
 
   const [updateGameSettings] = useMutation<
     UpdateGameSettingsMutation,
@@ -99,10 +102,9 @@ export default function GameSettingsEdit() {
                   data.introduction.length > 0 ? data.introduction : null,
                 catchImageFile:
                   catchImageFiles.length > 0 ? catchImageFiles[0] : null,
-                catchImageUrl:
-                  catchImageFiles.length > 0
-                    ? null
-                    : game.settings.background.catchImageUrl
+                // 新規アップロード時はファイル経由で送るので URL は null。
+                // それ以外は state で保持する preview URL（既存 URL or 削除後の null）。
+                catchImageUrl: catchImageFiles.length > 0 ? null : catchImageUrl
               },
               chara: {
                 charachipIds: charachipIds,
@@ -148,9 +150,9 @@ export default function GameSettingsEdit() {
       rating,
       theme,
       catchImageFiles,
+      catchImageUrl,
       charachipIds,
       game.id,
-      game.settings.background.catchImageUrl,
       router
     ]
   )
@@ -171,7 +173,8 @@ export default function GameSettingsEdit() {
         canModifyTheme={true}
         theme={theme}
         setTheme={setTheme}
-        catchImageUrl={game.settings.background.catchImageUrl ?? null}
+        catchImageUrl={catchImageUrl}
+        setCatchImageUrl={setCatchImageUrl}
         catchImages={catchImageFiles}
         setCatchImages={setCatchImageFiles}
       />

--- a/frontend/src/pages/create-game.tsx
+++ b/frontend/src/pages/create-game.tsx
@@ -47,6 +47,7 @@ export default function CreateGame() {
   const [rating, setRating] = useState('全年齢')
   const [charachipIds, setCharachipIds] = useState<string[]>([])
   const [catchImageFiles, setCatchImageFiles] = useState<File[]>([])
+  const [catchImageUrl, setCatchImageUrl] = useState<string | null>(null)
 
   const [registerGame] = useMutation<
     RegisterGameMutation,
@@ -149,7 +150,8 @@ export default function CreateGame() {
           charachipIds={charachipIds}
           setCharachipIds={setCharachipIds}
           canModifyTheme={false}
-          catchImageUrl={null}
+          catchImageUrl={catchImageUrl}
+          setCatchImageUrl={setCatchImageUrl}
           catchImages={catchImageFiles}
           setCatchImages={setCatchImageFiles}
         />

--- a/frontend/src/pages/create-game.tsx
+++ b/frontend/src/pages/create-game.tsx
@@ -47,6 +47,8 @@ export default function CreateGame() {
   const [rating, setRating] = useState('全年齢')
   const [charachipIds, setCharachipIds] = useState<string[]>([])
   const [catchImageFiles, setCatchImageFiles] = useState<File[]>([])
+  // 新規作成画面では submit 時に catchImageFile のみ送信するため、
+  // この state はプレビュー表示と削除ボタン制御のために InputImage に渡すだけ。
   const [catchImageUrl, setCatchImageUrl] = useState<string | null>(null)
 
   const [registerGame] = useMutation<

--- a/frontend/src/pages/release-note.tsx
+++ b/frontend/src/pages/release-note.tsx
@@ -25,6 +25,13 @@ export default function CreateGame() {
 
           <hr />
 
+          <ReleaseContent label='不具合修正' date='2026/05/11'>
+            <li>
+              修正:
+              プロフィール画像/ゲームキャッチ画像の削除ボタンを押して更新しても画像が消えない不具合を修正
+            </li>
+          </ReleaseContent>
+
           <ReleaseContent label='メンテナンス' date='2026/05/09'>
             <li>今後の変更に向けて大リファクタリング大会を実施中</li>
           </ReleaseContent>


### PR DESCRIPTION
## Summary

- `InputImage` を controlled 化し、`previewImageUrl` を親 state として一元管理
  - 旧: `defaultImageUrl` を `useState` の初期値にするだけで以降同期しない
  - 新: 親が `previewImageUrl` を保持し、削除時に `null` にする
- 親の submit ロジックを `images.length > 0 ? null : previewImageUrl` で統一
  - 新規アップロード時: ファイル経由で送るので URL は null
  - 削除時: previewImageUrl が null
  - 変更なし時: previewImageUrl は既存 URL のまま

## なぜ

`profile-edit.tsx` の submit が `images.length > 0 ? null : profile.profileImageUrl` という分岐になっており、削除ボタンを押しても無条件で既存 URL を送り直していた。`game-settings-edit.tsx` のキャッチ画像にも同じバグが存在。

## 影響範囲

- `frontend/src/components/form/input-image.tsx`: API 変更（`defaultImageUrl` 廃止 → `previewImageUrl` + `setPreviewImageUrl`）
- 呼び出し側 4 箇所:
  - `pages/games/profile/profile-edit.tsx` （バグ修正対象）
  - `pages/games/sidebar/game-settings-edit.tsx` （同パターンのバグ修正対象）
  - `pages/create-game/game-edit.tsx` （prop 経由でつなぐだけ）
  - `pages/create-game.tsx` （新規作成は影響なし、API 追従のみ）

## スコープ外

- **孤児画像ファイル**: DB 上の `profile_image_url` を NULL にしても storage 上の実ファイルは残る。Issue #34 でもスコープ外と明記、別 Issue 化候補。
- **`memo: null` 上書き問題**: `profile-edit.tsx` 内の TODO コメント。同種の問題の可能性があるが本 PR では触らない。

## Test plan

- [x] `pnpm run lint` PASS
- [x] `pnpm run build` PASS
- [x] `pnpm exec playwright test` 4/4 PASS
- [ ] **ユーザー手動確認依頼**: 既存 E2E ではカバーできないため以下を確認
  1. プロフィール画像削除→更新→再表示で消えていること
  2. プロフィール画像削除→新規画像選択→更新で新規画像に置き換わること
  3. プロフィール画像変更なし→更新で既存画像が保持されること
  4. ゲーム設定（GM）でキャッチ画像削除→更新→再表示で消えていること
  5. ゲーム作成画面でキャッチ画像選択→削除→再選択→作成で意図通り保存されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)