### PR TITLE
fix: 発言抽出のリセットでクリアと同時に再抽出も実行 (#30)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 .playwright-mcp
 .issues
 .reviews
+.tmp

--- a/e2e/tests/game-flow.spec.ts
+++ b/e2e/tests/game-flow.spec.ts
@@ -12,8 +12,9 @@ import { test, expect, type Page } from '@playwright/test'
 //   8. ユーザーBが通常発言
 //   9. ユーザーBがユーザーAの通常発言にリプライ
 //  10. ユーザーBがユーザーAに秘話送信
-//  11. ユーザーAが自分宛タブで秘話を確認
-//  12. ユーザーAがゲームのステータスを「終了」に変更
+//  11. ユーザーAが発言抽出（キーワード絞り込み→リセットで再抽出）を確認
+//  12. ユーザーAが自分宛タブで秘話を確認
+//  13. ユーザーAがゲームのステータスを「終了」に変更
 // ================================================================
 
 test('複数ユーザーシナリオ：ゲーム作成・参加・発言・リプライ・秘話', async ({
@@ -111,13 +112,40 @@ test('複数ユーザーシナリオ：ゲーム作成・参加・発言・リ�
   await postSecretTalk(pageB, bSecret)
 
   // ============================================================
-  // 11. ユーザーA: 自分宛タブで秘話を確認
+  // 11. ユーザーA: 発言抽出（キーワード絞り込み→リセットで再抽出）を確認
   // ============================================================
   await pageA.reload()
   await pageA.waitForURL(/\/chat-role-play\/games\/\d+/)
   await expect(pageA.locator('h1').filter({ hasText: gameName })).toBeVisible({
     timeout: 10_000
   })
+  // 抽出前は home に A/B 両方の通常発言が見える
+  await expect(
+    pageA.locator('#message-area-home').getByText(aNormal, { exact: true })
+  ).toBeVisible({ timeout: 10_000 })
+  await expect(
+    pageA.locator('#message-area-home').getByText(bNormal, { exact: true })
+  ).toBeVisible({ timeout: 10_000 })
+
+  // キーワード「Aの通常発言」で絞り込み → A のみ残り B は消える
+  await searchMessageByKeyword(pageA, 'Aの通常発言')
+  await expect(
+    pageA.locator('#message-area-home').getByText(aNormal, { exact: true })
+  ).toBeVisible({ timeout: 10_000 })
+  await expect(
+    pageA.locator('#message-area-home').getByText(bNormal, { exact: true })
+  ).toHaveCount(0)
+
+  // リセット押下（confirm を accept）→ モーダル閉じる、再抽出されて B が再表示
+  await resetMessageFilter(pageA)
+  await expect(pageA.getByRole('dialog')).toHaveCount(0)
+  await expect(
+    pageA.locator('#message-area-home').getByText(bNormal, { exact: true })
+  ).toBeVisible({ timeout: 10_000 })
+
+  // ============================================================
+  // 12. ユーザーA: 自分宛タブで秘話を確認
+  // ============================================================
   // 自分宛タブに切り替え、tome側メッセージエリアで秘話を確認
   await pageA
     .getByRole('button', { name: /自分宛/ })
@@ -127,7 +155,7 @@ test('複数ユーザーシナリオ：ゲーム作成・参加・発言・リ�
     pageA.locator('#message-area-tome').getByText(bSecret)
   ).toBeVisible({ timeout: 10_000 })
 
-  // 12. ユーザーA: ステータスを「終了」に変更
+  // 13. ユーザーA: ステータスを「終了」に変更
   await changeGameStatusToFinished(pageA)
 })
 
@@ -242,6 +270,38 @@ async function replyToTalk(
   const form = talkMessageTextarea.locator('xpath=ancestor::form')
   await form.locator('input[type="submit"][value="プレビュー"]').click()
   await page.getByRole('button', { name: '発言する' }).first().click()
+}
+
+async function openMessageFilterModal(page: Page): Promise<void> {
+  // home の MessageArea は #message-area-home の親 div 配下にフッターメニューを持つ。
+  // tome 側は searchable=false なのでフィルタボタンが生えないが、念のため home に scope。
+  await page
+    .locator('#message-area-home')
+    .locator('xpath=..')
+    .getByRole('button', { name: '発言抽出' })
+    .click()
+  await expect(page.getByRole('dialog')).toBeVisible()
+}
+
+async function searchMessageByKeyword(
+  page: Page,
+  keyword: string
+): Promise<void> {
+  await openMessageFilterModal(page)
+  const dialog = page.getByRole('dialog')
+  await dialog
+    .locator('input[placeholder="スペース区切りでOR検索"]')
+    .fill(keyword)
+  // 「検索（別タブ）」と区別するため exact: true
+  await dialog.getByRole('button', { name: '検索', exact: true }).click()
+  await expect(page.getByRole('dialog')).toHaveCount(0)
+}
+
+async function resetMessageFilter(page: Page): Promise<void> {
+  await openMessageFilterModal(page)
+  // window.confirm を accept
+  page.once('dialog', (dialog) => dialog.accept())
+  await page.getByRole('dialog').getByRole('button', { name: 'リセット' }).click()
 }
 
 async function postSecretTalk(page: Page, text: string): Promise<void> {

--- a/e2e/tests/game-flow.spec.ts
+++ b/e2e/tests/game-flow.spec.ts
@@ -299,8 +299,9 @@ async function searchMessageByKeyword(
 
 async function resetMessageFilter(page: Page): Promise<void> {
   await openMessageFilterModal(page)
-  // window.confirm を accept
-  page.once('dialog', (dialog) => dialog.accept())
+  // window.confirm を accept（page.on('dialog') の dialog はネイティブダイアログ。
+  // 上で扱う getByRole('dialog') の React モーダルとは別物なので nativeDialog と命名）
+  page.once('dialog', (nativeDialog) => nativeDialog.accept())
   await page.getByRole('dialog').getByRole('button', { name: 'リセット' }).click()
 }
 

--- a/frontend/src/components/pages/games/article/message-area/direct-message/direct-message-filter.tsx
+++ b/frontend/src/components/pages/games/article/message-area/direct-message/direct-message-filter.tsx
@@ -40,11 +40,25 @@ export default function DirectMessageFilter(props: Props) {
   )
 
   const handleReset = () => {
-    if (!window.confirm('検索条件をリセットしてよろしいですか？')) return
+    if (!window.confirm('検索条件をリセットして再抽出します。よろしいですか？'))
+      return
     setSenders([])
     setKeyword('')
     setSinceAt(null)
     setUntilAt(null)
+    const newQuery: DirectMessagesQuery = {
+      ...messageQuery,
+      senderIds: null,
+      keywords: null,
+      sinceAt: null,
+      untilAt: null,
+      paging: {
+        ...messageQuery.paging!,
+        pageNumber: 1
+      }
+    }
+    search(newQuery)
+    close()
   }
 
   const handleSearch = () => {

--- a/frontend/src/components/pages/games/article/message-area/direct-message/direct-message-filter.tsx
+++ b/frontend/src/components/pages/games/article/message-area/direct-message/direct-message-filter.tsx
@@ -46,7 +46,7 @@ export default function DirectMessageFilter(props: Props) {
     setKeyword('')
     setSinceAt(null)
     setUntilAt(null)
-    const newQuery: DirectMessagesQuery = {
+    const resetQuery: DirectMessagesQuery = {
       ...messageQuery,
       senderIds: null,
       keywords: null,
@@ -57,7 +57,7 @@ export default function DirectMessageFilter(props: Props) {
         pageNumber: 1
       }
     }
-    search(newQuery)
+    search(resetQuery)
     close()
   }
 

--- a/frontend/src/components/pages/games/article/message-area/message-area/message-filter.tsx
+++ b/frontend/src/components/pages/games/article/message-area/message-area/message-filter.tsx
@@ -61,7 +61,7 @@ export default function MessageFilter(props: Props) {
     setKeyword('')
     setSinceAt(null)
     setUntilAt(null)
-    const query: MessagesQuery = {
+    const resetQuery: MessagesQuery = {
       ...messageQuery,
       types: null,
       senderIds: null,
@@ -74,7 +74,7 @@ export default function MessageFilter(props: Props) {
         pageNumber: 1
       }
     }
-    search(query)
+    search(resetQuery)
     close()
   }
 

--- a/frontend/src/components/pages/games/article/message-area/message-area/message-filter.tsx
+++ b/frontend/src/components/pages/games/article/message-area/message-area/message-filter.tsx
@@ -53,13 +53,29 @@ export default function MessageFilter(props: Props) {
   )
 
   const handleReset = () => {
-    if (!window.confirm('検索条件をリセットしてよろしいですか？')) return
+    if (!window.confirm('検索条件をリセットして再抽出します。よろしいですか？'))
+      return
     setTypes(messageTypeValues)
     setSenders([])
     setReceivers([])
     setKeyword('')
     setSinceAt(null)
     setUntilAt(null)
+    const query: MessagesQuery = {
+      ...messageQuery,
+      types: null,
+      senderIds: null,
+      recipientIds: null,
+      keywords: null,
+      sinceAt: null,
+      untilAt: null,
+      paging: {
+        ...messageQuery.paging!,
+        pageNumber: 1
+      }
+    }
+    search(query)
+    close()
   }
 
   const handleSearch = () => {

--- a/frontend/src/pages/release-note.tsx
+++ b/frontend/src/pages/release-note.tsx
@@ -30,6 +30,10 @@ export default function CreateGame() {
               修正:
               プロフィール画像/ゲームキャッチ画像の削除ボタンを押して更新しても画像が消えない不具合を修正
             </li>
+            <li>
+              変更:
+              発言抽出のリセットボタンで、条件クリアと同時に再抽出も実行するよう変更
+            </li>
           </ReleaseContent>
 
           <ReleaseContent label='メンテナンス' date='2026/05/09'>


### PR DESCRIPTION
closes .issues/30-message-filter-reset-also-search.md

## 変更内容

- 通常メッセージ・DM の両フィルタで、リセット押下時に
  - 条件 state を初期値にリセット
  - リセット後の値（全 null）から直接クエリを組み立てて `search` を発火
  - モーダルを `close()`
  を一気通貫で実行
- state 更新は非同期なので `handleSearch` を流用せず、リセット後の値から直接クエリを組み立てる方針
- confirm 文言を「検索条件をリセットして再抽出します。よろしいですか？」に変更（実際の挙動と一致させる）
- E2E (`game-flow.spec.ts`) に発言抽出シナリオを追加
  - キーワードで絞り込み → A の発言のみ残り B が消える
  - リセット押下（confirm accept）→ モーダル閉じる、再抽出されて B が再表示
- release-note 2026/05/11 に追記

## レビュー反映

- should-fix: `handleReset` の `query` 変数を `resetQuery` にリネーム（`handleSearch` の `query` と同名で混乱を招くため）。DM 側の `newQuery` も対称性のため `resetQuery` に揃えた
- nit 1: E2E の `page.once('dialog', ...)` のパラメータを `nativeDialog` にリネーム（`getByRole('dialog')` と区別）
- nit 2 (見送り): footer menu の親要素取得を `xpath=..` ではなく `data-testid` 等で堅牢にする件は scope 外として保留。本 PR では footer menu コンポーネント自体に手を入れたくない（home/tome/DM 共用で影響範囲が広い）。将来同種の追加 helper が増えたら id 付与含めまとめて見直し

## 動作確認

- [x] `pnpm run lint`
- [x] 既存 E2E: `cd e2e && pnpm exec playwright test`（4 passed）
- [x] 追加 E2E: 発言抽出（キーワード絞り込み → リセットで再抽出）を `game-flow` に追加
