### PR TITLE
fix: 発言パネル固定表示の見切れと高さ占有を見直す (#27 #35)

### DIFF
--- a/frontend/src/components/pages/games/article/message-area/direct-message/direct-message-area.tsx
+++ b/frontend/src/components/pages/games/article/message-area/direct-message/direct-message-area.tsx
@@ -32,6 +32,7 @@ import { useGameValue } from '@/components/pages/games/game-hook'
 import Panel from '@/components/panel/panel'
 import TalkDirect from '../../../talk/talk-direct'
 import { base64ToId } from '@/components/graphql/convert'
+import FixedPanelWrapper from '../fixed-panel-wrapper'
 
 type Props = {
   close: () => void
@@ -311,9 +312,7 @@ const DirectTalkPanel = (props: DirectTalkAreaProps) => {
   } else {
     return (
       <Portal target={`#${props.talkAreaId}-fixed`}>
-        <div className='-m-4 max-h-[40vh] overflow-y-scroll md:max-h-full md:overflow-y-hidden'>
-          {panel}
-        </div>
+        <FixedPanelWrapper>{panel}</FixedPanelWrapper>
       </Portal>
     )
   }

--- a/frontend/src/components/pages/games/article/message-area/fixed-panel-wrapper.tsx
+++ b/frontend/src/components/pages/games/article/message-area/fixed-panel-wrapper.tsx
@@ -6,6 +6,7 @@ type Props = {
 
 // 発言・ト書き・GM発言・DMの「固定」表示時の共通ラッパ。
 // スマホ: max-h-[30vh] / PC(md+): max-h-[35vh]、いずれも縦スクロール可。
+// overflow-y-scroll は集約前 4 箇所すべての挙動を維持するため auto ではなく scroll。
 export default function FixedPanelWrapper({ children }: Props) {
   return (
     <div className='max-h-[30vh] overflow-y-scroll md:max-h-[35vh]'>

--- a/frontend/src/components/pages/games/article/message-area/fixed-panel-wrapper.tsx
+++ b/frontend/src/components/pages/games/article/message-area/fixed-panel-wrapper.tsx
@@ -1,0 +1,15 @@
+import { ReactNode } from 'react'
+
+type Props = {
+  children: ReactNode
+}
+
+// 発言・ト書き・GM発言・DMの「固定」表示時の共通ラッパ。
+// スマホ: max-h-[30vh] / PC(md+): max-h-[35vh]、いずれも縦スクロール可。
+export default function FixedPanelWrapper({ children }: Props) {
+  return (
+    <div className='max-h-[30vh] overflow-y-scroll md:max-h-[35vh]'>
+      {children}
+    </div>
+  )
+}

--- a/frontend/src/components/pages/games/article/message-area/message-area/talk-area.tsx
+++ b/frontend/src/components/pages/games/article/message-area/message-area/talk-area.tsx
@@ -8,6 +8,7 @@ import Talk from '../../../talk/talk'
 import TalkDescription from '../../../talk/talk-description'
 import TalkSystem from '../../../talk/talk-system'
 import { useTalkPanel } from '../../../talk/use-talk-panel'
+import FixedPanelWrapper from '../fixed-panel-wrapper'
 
 type TalkAreaProps = {
   canTalk: boolean
@@ -72,9 +73,7 @@ const TalkPanel = ({ search, talkAreaId }: TalkPanelProps) => {
   } else {
     return (
       <Portal target={`#${talkAreaId}-fixed`}>
-        <div className='max-h-[40vh] overflow-y-scroll md:max-h-full md:overflow-y-hidden'>
-          {panel}
-        </div>
+        <FixedPanelWrapper>{panel}</FixedPanelWrapper>
       </Portal>
     )
   }
@@ -107,9 +106,7 @@ const DescriptionPanel = ({
   } else {
     return (
       <Portal target={`#${talkAreaId}-fixed`}>
-        <div className='max-h-[40vh] overflow-y-scroll md:max-h-full md:overflow-y-hidden'>
-          {panel}
-        </div>
+        <FixedPanelWrapper>{panel}</FixedPanelWrapper>
       </Portal>
     )
   }
@@ -155,9 +152,7 @@ const SystemMessagePanel = ({
   } else {
     return (
       <Portal target={`#${talkAreaId}-fixed`}>
-        <div className='max-h-[40vh] overflow-y-scroll md:max-h-full md:overflow-y-hidden'>
-          {panel}
-        </div>
+        <FixedPanelWrapper>{panel}</FixedPanelWrapper>
       </Portal>
     )
   }

--- a/frontend/src/pages/release-note.tsx
+++ b/frontend/src/pages/release-note.tsx
@@ -34,6 +34,14 @@ export default function CreateGame() {
               変更:
               発言抽出のリセットボタンで、条件クリアと同時に再抽出も実行するよう変更
             </li>
+            <li>
+              修正:
+              ダイレクトメッセージの発言パネルを下部固定にすると左右が見切れる不具合を修正
+            </li>
+            <li>
+              変更: 発言パネル下部固定時の高さをスマホ 30vh / PC 35vh に調整（PC
+              は従来上限なしのため大きく占有していた）
+            </li>
           </ReleaseContent>
 
           <ReleaseContent label='メンテナンス' date='2026/05/09'>


### PR DESCRIPTION
closes .issues/27-dm-talk-panel-fixed-overflow.md
closes .issues/35-fixed-panel-height-tuning.md

DM の発言パネル固定時の見切れ (#27) と、固定パネルの高さ占有過大 (#35) を同領域につき 1 PR でまとめて修正。

## 変更内容

- **共通ラッパ `FixedPanelWrapper` を新設** (`frontend/src/components/pages/games/article/message-area/fixed-panel-wrapper.tsx`)
  - `talk-area.tsx` 3 箇所（発言・ト書き・GM発言）と `direct-message-area.tsx` 1 箇所、計 4 箇所で重複していた className 文字列を集約
  - 今後の高さ調整が 1 ヶ所で済む
- **#27**: DM 側の固定ラッパに付いていた `-m-4`（負マージン）を削除
- **#35**: 高さキャップを以下に変更
  - スマホ: `max-h-[30vh]`（従来 40vh、下バーが 2 段ぶんあるぶん圧迫されていたので圧縮）
  - PC（md+）: `max-h-[35vh]`（従来は上限なしで画面占有が大きかった）
  - PC でも `overflow-y-scroll` を有効化
- release-note 2026/05/11 に追記

### `-m-4` 削除の根拠

DM 側の固定ラッパに付いていた `-m-4` がいつ・なぜ追加されたかは git blame でも追えなかったが、以下より外側に食み出していただけと判断した:

- Panel 内部の余白 `p-4` (`panel.tsx:61`) は `<div className='primary-text w-full p-4'>{children}</div>` で children に効く **内側** padding。外側に `-m-4` をつけても打ち消し関係にならない
- `#${talkAreaId}-fixed` portal target の親（`direct-message-area.tsx` の `<div className='flex h-full flex-col overflow-y-auto'>`）には padding がない。`-m-4` で打ち消す対象が存在しなかった
- 通常メッセージ側（`talk-area.tsx`）の固定時は元から `-m-4` なしで問題なかったので、それと揃える形

### 非固定時の見た目差について（既存・本 PR スコープ外）

- 通常メッセージ非固定: `<div className='m-4'>{panel}</div>`
- DM 非固定: `return panel`（margin なし）

これは元から差異がある実装で、本 PR では非固定時のレイアウトに変更を加えていない。

### `overflow-y-scroll` を採用している理由

`overflow-y-auto` ではなく `overflow-y-scroll` を採用しているのは、変更前の 4 箇所すべて `overflow-y-scroll` だったため挙動を変えないことを優先（コンテンツが収まっている時もスクロールバー領域を確保する）。

## 動作確認

- [x] `pnpm run lint`
- [x] 既存 E2E: `cd e2e && pnpm exec playwright test`（4 passed）
- [ ] **ユーザー手動確認依頼**:
  - DM の発言パネルを「下部固定」表示にして左右が見切れないこと
  - 通常メッセージ／ト書き／GM 発言／DM のいずれでも、固定表示の高さが PC 35vh / スマホ 30vh に収まること
  - 通常表示（非固定）には影響していないこと
  - スマホ実機で下バーと干渉しないこと

数値（30vh / 35vh）はユーザーフィードバックを取り込み調整中。違和感があれば追って調整します。
