### PR TITLE
fix: 投げ銭モーダルの Amazon アソシエイトを iframe からテキストリンクに変更 (#28)

### DIFF
--- a/frontend/src/components/pages/index/tip.tsx
+++ b/frontend/src/components/pages/index/tip.tsx
@@ -43,12 +43,9 @@ export default function Tip() {
           </li>
         </ul>
         <div className='flex justify-end'>
-          <iframe
-            src='https://rcm-fe.amazon-adsystem.com/e/cm?o=9&p=20&l=ez&f=ifr&linkID=c5438f7fc033eeee42260876403c6c51&t=wolfort0d-22&tracking_id=wolfort0d-22'
-            className='border border-gray-300'
-            scrolling='no'
-            style={{ border: 'none', width: '120px', height: '90px' }}
-          ></iframe>
+          <a href='https://amzn.to/48auG7Q' target='_blank' rel='noreferrer'>
+            <PrimaryButton>Amazonに遷移</PrimaryButton>
+          </a>
         </div>
       </div>
       <hr />

--- a/frontend/src/pages/release-note.tsx
+++ b/frontend/src/pages/release-note.tsx
@@ -42,6 +42,11 @@ export default function CreateGame() {
               変更: 発言パネル下部固定時の高さをスマホ 30vh / PC 35vh に調整（PC
               は従来上限なしのため大きく占有していた）
             </li>
+            <li>
+              修正: 投げ銭モーダルの Amazon アソシエイトを iframe
+              からテキストリンクに変更（iframe 形式が Amazon
+              側で非対応となったため）
+            </li>
           </ReleaseContent>
 
           <ReleaseContent label='メンテナンス' date='2026/05/09'>


### PR DESCRIPTION
closes .issues/28-tip-amazon-associate-link.md

Amazon アソシエイトの仕様変更で iframe 形式の商品リンクが非対応となったため、テキストリンクに置き換え。

## 変更内容

- `frontend/src/components/pages/index/tip.tsx`: `<iframe src='https://rcm-fe.amazon-adsystem.com/...'>` を削除
- 他セクション（ほしいものリスト / ギフト券 / Fanbox）と同じ形式の `<a href='https://amzn.to/48auG7Q' target='_blank' rel='noreferrer'><PrimaryButton>Amazonに遷移</PrimaryButton></a>` に置き換え
- release-note 2026/05/11 に追記

## 動作確認

- [x] `pnpm run lint`
- [x] 既存 E2E: `cd e2e && pnpm exec playwright test`（4 passed）
- [ ] **ユーザー手動確認依頼**:
  - 投げ銭モーダルの「Amazonアソシエイト経由での買い物」セクションに「Amazonに遷移」ボタンが表示されること
  - ボタンをクリックすると新規タブで Amazon 商品ページが開くこと
  - 他のセクション（ほしいものリスト / ギフト券 / Fanbox）と見た目が揃っていること
