### PR TITLE
fix: スマホでアイコン並び替えの上下移動ができない不具合を修正 (#33)

### DIFF
--- a/frontend/src/components/pages/games/profile/participant-icon-edit.tsx
+++ b/frontend/src/components/pages/games/profile/participant-icon-edit.tsx
@@ -100,7 +100,14 @@ const IconSortArea = ({
   const game = useGameValue()
   // see https://iwaking.com/blog/sort-images-with-dnd-kit-react-typescript
   const [activeIcon, setActiveIcon] = useState<GameParticipantIcon>()
-  const sensors = useSensors(useSensor(PointerSensor), useSensor(TouchSensor))
+  const sensors = useSensors(
+    useSensor(PointerSensor, {
+      activationConstraint: { distance: 5 }
+    }),
+    useSensor(TouchSensor, {
+      activationConstraint: { delay: 150, tolerance: 5 }
+    })
+  )
   const handleDragStart = (event: DragStartEvent) => {
     const { active } = event
     setActiveIcon(icons.find((icon) => icon.id === active.id))
@@ -224,6 +231,7 @@ const Icon = forwardRef<HTMLDivElement, IconProps>(
       cursor: isDragging ? 'grabbing' : 'grab',
       lineHeight: '0.5',
       transform: isDragging ? 'scale(1.05)' : 'scale(1)',
+      touchAction: 'none',
       ...style
     }
 

--- a/frontend/src/components/pages/games/profile/participant-icon-edit.tsx
+++ b/frontend/src/components/pages/games/profile/participant-icon-edit.tsx
@@ -105,7 +105,7 @@ const IconSortArea = ({
       activationConstraint: { distance: 5 }
     }),
     useSensor(TouchSensor, {
-      activationConstraint: { delay: 150, tolerance: 5 }
+      activationConstraint: { delay: 250, tolerance: 5 }
     })
   )
   const handleDragStart = (event: DragStartEvent) => {
@@ -211,6 +211,7 @@ const SortableItem = ({ icon, ...props }: SortableItemProps) => {
       icon={icon}
       ref={setNodeRef}
       isOpacityEnabled={isDragging}
+      style={{ touchAction: 'none' }}
       {...props}
       {...attributes}
       {...listeners}
@@ -231,7 +232,6 @@ const Icon = forwardRef<HTMLDivElement, IconProps>(
       cursor: isDragging ? 'grabbing' : 'grab',
       lineHeight: '0.5',
       transform: isDragging ? 'scale(1.05)' : 'scale(1)',
-      touchAction: 'none',
       ...style
     }
 

--- a/frontend/src/pages/release-note.tsx
+++ b/frontend/src/pages/release-note.tsx
@@ -47,6 +47,10 @@ export default function CreateGame() {
               からテキストリンクに変更（iframe 形式が Amazon
               側で非対応となったため）
             </li>
+            <li>
+              修正:
+              スマホでアイコン並び替え時に上下方向への入れ替えができない不具合を修正
+            </li>
           </ReleaseContent>
 
           <ReleaseContent label='メンテナンス' date='2026/05/09'>


### PR DESCRIPTION
## Summary

- スマホでプロフィール画像のアイコン並び替え時、上下方向（行をまたぐ）のドラッグができない不具合を修正（#33）
- `TouchSensor` に `activationConstraint: { delay: 150, tolerance: 5 }` を付与し、長押し起動でブラウザのスクロールジェスチャと競合しないようにした
- `PointerSensor` にも `activationConstraint: { distance: 5 }` を入れて誤タップでのドラッグ判定を抑制
- `SortableItem` の style に `touchAction: 'none'` を付与し、行をまたぐドラッグ中にページスクロールへ奪われないようにした

## 変更ファイル

- `frontend/src/components/pages/games/profile/participant-icon-edit.tsx`
- `frontend/src/pages/release-note.tsx`（リリースノート追記）

## Test plan

- [x] `pnpm run lint`（パス）
- [x] `pnpm exec playwright test`（4 tests パス、31.8s）
- [ ] **ユーザー手動確認依頼**: スマホ実機（iOS Safari / Android Chrome）で
  - アイコンを7枚以上アップロードし、1行目→2行目への上下移動が安定して行えること
  - 「反映」ボタンで `displayOrder` が正しく更新されること
- [ ] **ユーザー手動確認依頼**: PC（マウス）でのドラッグに回帰がないこと（誤発火・遅延が増えていない）
  - `PointerSensor` に `distance: 5` を入れたため、ごく短い距離のドラッグは発火しなくなる（5px 以上動かせば発火）

🤖 Generated with [Claude Code](https://claude.com/claude-code)