### PR TITLE
chore: target='_blank' な Link/a 全体に rel='noreferrer' を付与 (#29)

### DIFF
--- a/frontend/.eslintrc.json
+++ b/frontend/.eslintrc.json
@@ -16,6 +16,7 @@
   "rules": {
     "react-hooks/exhaustive-deps": "warn",
     "@next/next/no-img-element": "off",
+    "react/jsx-no-target-blank": ["error", { "allowReferrer": false }],
     "tailwindcss/no-custom-classname": ["warn", {
       "whitelist": [
         "base-.+",

--- a/frontend/.eslintrc.json
+++ b/frontend/.eslintrc.json
@@ -16,6 +16,7 @@
   "rules": {
     "react-hooks/exhaustive-deps": "warn",
     "@next/next/no-img-element": "off",
+    // next/core-web-vitals が "off" にしているため明示的に上書き
     "react/jsx-no-target-blank": ["error", { "allowReferrer": false }],
     "tailwindcss/no-custom-classname": ["warn", {
       "whitelist": [

--- a/frontend/src/components/pages/games/article/message-area/direct-message/direct-message.tsx
+++ b/frontend/src/components/pages/games/article/message-area/direct-message/direct-message.tsx
@@ -179,6 +179,7 @@ const SenderName = ({
         directMessage.sender!.participantId
       )}`}
       target='_blank'
+      rel='noreferrer'
     >
       {name}
     </Link>
@@ -213,6 +214,7 @@ const SenderIcon = ({
         directMessage.sender!.participantId
       )}`}
       target='_blank'
+      rel='noreferrer'
     >
       {icon}
     </Link>

--- a/frontend/src/components/pages/games/article/message-area/message-area/message-filter.tsx
+++ b/frontend/src/components/pages/games/article/message-area/message-area/message-filter.tsx
@@ -488,6 +488,7 @@ const NewTabFilterLink = (props: NewTabFilterLinkProps) => {
         )
       }}
       target='_blank'
+      rel='noreferrer'
     >
       <PrimaryButton className='ml-2' click={() => {}}>
         検索（別タブ）

--- a/frontend/src/components/pages/games/article/message-area/message-area/messages-area/message/sender-name.tsx
+++ b/frontend/src/components/pages/games/article/message-area/message-area/messages-area/message/sender-name.tsx
@@ -25,6 +25,7 @@ export const SenderName = ({ message, preview }: Props) => {
         message.sender!.participantId
       )}`}
       target='_blank'
+      rel='noreferrer'
     >
       {name}
     </Link>

--- a/frontend/src/components/pages/games/article/message-area/message-area/messages-area/message/talk-message.tsx
+++ b/frontend/src/components/pages/games/article/message-area/message-area/messages-area/message/talk-message.tsx
@@ -145,6 +145,7 @@ const ReceiverName = ({
           message.receiver!.participantId
         )}`}
         target='_blank'
+        rel='noreferrer'
       >
         {name}
       </Link>
@@ -180,6 +181,7 @@ const SenderIcon = ({
         message.sender!.participantId
       )}`}
       target='_blank'
+      rel='noreferrer'
     >
       {icon}
     </Link>
@@ -321,6 +323,7 @@ const ReplyToMessage = ({ message }: { message: Message }) => {
             message.id
           )}`}
           target='_blank'
+          rel='noreferrer'
         >
           <p>
             →&nbsp;#{replyToMessage.content.number}&nbsp;

--- a/frontend/src/components/pages/games/participant/participants.tsx
+++ b/frontend/src/components/pages/games/participant/participants.tsx
@@ -21,6 +21,7 @@ export default function Participants({ className, participants }: Props) {
             participant.id
           )}`}
           target='_blank'
+          rel='noreferrer'
           key={participant.id}
           className='base-border flex rounded-md border p-4 hover:bg-gray-100'
         >

--- a/frontend/src/components/pages/games/sidebar/game-settings.tsx
+++ b/frontend/src/components/pages/games/sidebar/game-settings.tsx
@@ -33,6 +33,7 @@ export default function GameSettings({ close }: GameSettingsProps) {
                   className='base-link'
                   href={`/charachips/${base64ToId(c.id)}`}
                   target='_blank'
+                  rel='noreferrer'
                 >
                   {c.name}
                 </Link>

--- a/frontend/src/components/pages/games/sidebar/participate.tsx
+++ b/frontend/src/components/pages/games/sidebar/participate.tsx
@@ -122,7 +122,12 @@ export default function Participate({ close }: Props) {
             onChange={() => setCheckedTerm((prev) => !prev)}
           />
           <label htmlFor='term-check' className='ml-2 text-xs'>
-            <Link target='_blank' href='/rules' className='base-link'>
+            <Link
+              target='_blank'
+              rel='noreferrer'
+              href='/rules'
+              className='base-link'
+            >
               ルール
             </Link>
             を確認し、守るべき事項について理解しました。

--- a/frontend/src/components/pages/games/sidebar/sidebar.tsx
+++ b/frontend/src/components/pages/games/sidebar/sidebar.tsx
@@ -295,6 +295,7 @@ const ProfileButton = () => {
       <Link
         href={`/games/${base64ToId(game.id)}/profile/${base64ToId(myself.id)}`}
         target='_blank'
+        rel='noreferrer'
         className='sidebar-text sidebar-hover flex w-full justify-start px-4 py-2 text-sm'
       >
         <UserCircleIcon className='mr-1 size-5' />

--- a/frontend/src/pages/charachips/[id].tsx
+++ b/frontend/src/pages/charachips/[id].tsx
@@ -55,6 +55,7 @@ export default function CharachipPage({ charachipId, charachip }: Props) {
               <a
                 href={charachip.descriptionUrl}
                 target='_blank'
+                rel='noreferrer'
                 className='base-link'
               >
                 {charachip.descriptionUrl}

--- a/frontend/src/pages/instructions.tsx
+++ b/frontend/src/pages/instructions.tsx
@@ -86,6 +86,7 @@ export default function Instructions() {
                         <Link
                           href={'/rules'}
                           target='_blank'
+                          rel='noreferrer'
                           className='text-blue-500'
                         >
                           ルール
@@ -97,6 +98,7 @@ export default function Instructions() {
                         <Link
                           href={'/rules'}
                           target='_blank'
+                          rel='noreferrer'
                           className='text-blue-500'
                         >
                           ルール


### PR DESCRIPTION
closes .issues/29-rel-noreferrer-audit.md

## Summary

- `target='_blank'` で `rel` 未指定の箇所を grep で網羅し、14 箇所（内部 Next.js `<Link>` 13 / 外部 `<a>` 1）に `rel='noreferrer'` を付与
- ESLint `react/jsx-no-target-blank` を `error` で有効化し、`<a>` の将来のリグレッションを lint で防ぐ
  - Next.js `<Link>` は React コンポーネント扱いのため本 ESLint ルールの対象外（既知の制限）。今回手動で網羅済み

## 変更ファイル

- `frontend/.eslintrc.json` （ルール追加）
- 10 ファイル（`<Link target='_blank'>` および 1 件の外部 `<a>`）

## なぜ `noreferrer` のみで OK か

- HTML 仕様上、`rel='noreferrer'` は `rel='noopener'` の動作を含む（リファラ送信と `window.opener` 経由の親ページ操作の両方を抑止）
- そのため `rel='noopener noreferrer'` と書く必要はない（短くて等価）

## Test plan

- [x] `pnpm run lint` （パス、`react/jsx-no-target-blank` 違反なし）
- [x] `pnpm run build` （パス）
- [x] `cd e2e && pnpm exec playwright test` （4 tests パス、31.8s）

## リリースノート

純内部の a11y/セキュリティ衛生のため追記なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)