### PR TITLE
fix: delivery frontend の Dockerfile を next.config.ts に追随 (#36)

### DIFF
--- a/.github/workflows/deploy_backend.yml
+++ b/.github/workflows/deploy_backend.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: [self-hosted]
     steps:
       - name: clone repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Go
         uses: actions/setup-go@v4

--- a/.github/workflows/deploy_frontend.yml
+++ b/.github/workflows/deploy_frontend.yml
@@ -18,7 +18,7 @@ jobs:
           docker system prune --force
 
       - name: clone repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: build
         run: >

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -9,7 +9,7 @@ WORKDIR /app
 COPY src src
 COPY tsconfig.json tsconfig.json
 COPY package.json pnpm-lock.yaml ./
-COPY next.config.js next.config.js
+COPY next.config.ts next.config.ts
 COPY tailwind.config.js tailwind.config.js
 COPY postcss.config.js postcss.config.js
 COPY public public
@@ -28,7 +28,7 @@ ENV NEXT_PUBLIC_GRAPHQL_INNER_ENDPOINT=${GRAPHQL_INNER_ENDPOINT}
 RUN pnpm install --frozen-lockfile
 RUN pnpm build
 
-ENV NODE_ENV production
+ENV NODE_ENV=production
 RUN addgroup --system --gid 1001 nodejs
 RUN adduser --system --uid 1001 nextjs
 ENV HOME=/home/nextjs
@@ -40,7 +40,7 @@ RUN chown nextjs:nodejs /app/.next/cache
 USER nextjs
 
 EXPOSE 3000
-ENV PORT 3000
-ENV HOST 0.0.0.0
+ENV PORT=3000
+ENV HOST=0.0.0.0
 
 CMD ["pnpm", "start"]

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -26,9 +26,10 @@ ARG GRAPHQL_INNER_ENDPOINT
 ENV NEXT_PUBLIC_GRAPHQL_INNER_ENDPOINT=${GRAPHQL_INNER_ENDPOINT}
 
 RUN pnpm install --frozen-lockfile
-RUN pnpm build
 
 ENV NODE_ENV=production
+RUN pnpm build
+
 RUN addgroup --system --gid 1001 nodejs
 RUN adduser --system --uid 1001 nextjs
 ENV HOME=/home/nextjs


### PR DESCRIPTION
closes .issues/36-deploy-frontend-dockerfile-next-config.md

## 背景

`main` への push をトリガとする `delivery frontend` ワークフローが PR #26 以降ずっと失敗し、本番フロントエンドが過去 8 PR 分デプロイされていない状態だった。原因は `frontend/Dockerfile` の `COPY next.config.js next.config.js` で、リポジトリ上は `next.config.ts` のみ存在するため Docker build が `failed to compute cache key: "/next.config.js": not found` で落ちていた。

## 変更内容

- `frontend/Dockerfile`: `COPY next.config.js next.config.js` → `COPY next.config.ts next.config.ts`（CI 失敗の主因）
- `frontend/Dockerfile`: `ENV key value` → `ENV key=value` 形式に変更（LegacyKeyValueFormat 警告 3 件解消、`NODE_ENV` / `PORT` / `HOST`）
- `.github/workflows/deploy_frontend.yml`: `actions/checkout@v2` → `@v4`
- `.github/workflows/deploy_backend.yml`: `actions/checkout@v3` → `@v4`（同パターンで Node.js 20 deprecation 警告対象だったため併せて更新）

## スコープ外

build-arg のセキュア化（GitHub Secrets → BuildKit secret mount 等）については別 Issue `.issues/37-graphql-inner-endpoint-runtime-env.md` を起票済み。`NEXT_PUBLIC_*` は Next.js 仕様上クライアントバンドルに焼き込まれるため build-arg 経路を変えても実効性が無く、唯一意味のある `NEXT_PUBLIC_GRAPHQL_INNER_ENDPOINT` の接頭辞除去は k8s manifest 修正（リポ外）を伴うため切り出して扱う。

## 動作確認

- [x] `pnpm run lint`
- [x] `pnpm run build`（Dockerfile 内の `pnpm build` と同等のフロー）
- [ ] マージ後の `delivery frontend` ワークフローがグリーンになることを確認
- [ ] ユーザー手動確認依頼: 本番デプロイ後にフロントエンドが最新コードで稼働しているか（release-note 等で確認）

ローカル `docker build ./frontend` はランナーが arm64v8/node:24-bookworm でホストが arm64 Mac ではない環境を含むため未実行。CI のセルフホストランナー（arm64）での成否で最終確認とする。