### PR TITLE
chore: pnpm のサプライチェーン攻撃対策を追加 (#39)

### DIFF
--- a/e2e/.npmrc
+++ b/e2e/.npmrc
@@ -1,0 +1,1 @@
+minimum-release-age=10080

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -16,5 +16,8 @@
     "@playwright/test": "^1.59.1",
     "@types/node": "^25.6.0",
     "dotenv": "^17.4.2"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": []
   }
 }

--- a/frontend/.npmrc
+++ b/frontend/.npmrc
@@ -1,0 +1,1 @@
+minimum-release-age=10080

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,14 +1,14 @@
 FROM arm64v8/node:24-bookworm
 
 # pnpm をインストール
-RUN corepack enable && corepack prepare pnpm@latest --activate
+RUN corepack enable && corepack prepare pnpm@10.33.0 --activate
 
 WORKDIR /app
 
 # Install dependencies based on the preferred package manager
 COPY src src
 COPY tsconfig.json tsconfig.json
-COPY package.json pnpm-lock.yaml ./
+COPY package.json pnpm-lock.yaml .npmrc ./
 COPY next.config.ts next.config.ts
 COPY tailwind.config.js tailwind.config.js
 COPY postcss.config.js postcss.config.js

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -60,5 +60,10 @@
     "tailwindcss": "^3.3.2",
     "typescript": "5.7.2",
     "vitest": "^4.1.0"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "sharp"
+    ]
   }
 }


### PR DESCRIPTION
closes .issues/39-pnpm-supply-chain-hardening.md

## 背景

2025 年に多発した npm サプライチェーン攻撃（Shai-Hulud worm、tinycolor 系汚染など）への防御強化。
現状の防御は `pnpm install --frozen-lockfile` のみで、`pnpm update` で lockfile を更新する瞬間に汚染版を引くリスクがあった。

ユーザーのローカル pnpm config には既に `minimum-release-age=1440` / `minimumReleaseAge=10080` が設定済みだが、CI（self-hosted runner）は別ユーザー環境のため引き継がれない。プロジェクト固有の `.npmrc` を作成して、開発者ローカル・新規開発者環境・CI で一律に効くようにする。

## 変更内容

- `frontend/.npmrc` 新規: `minimum-release-age=10080`（7 日）
- `e2e/.npmrc` 新規: 同上
- `frontend/package.json`: `pnpm.onlyBuiltDependencies: ["sharp"]` を明示
- `e2e/package.json`: `pnpm.onlyBuiltDependencies: []` を明示（将来の dep 追加時に build script を自動拒否）
- `frontend/Dockerfile`: `COPY package.json pnpm-lock.yaml .npmrc ./` に変更し、Docker build 時にも `.npmrc` が反映される
- `frontend/Dockerfile`: `corepack prepare pnpm@latest` → `pnpm@10.33.0` で `packageManager` フィールドと完全一致させる

## `minimum-release-age` の効果範囲

- **lockfile を更新する操作（`pnpm add` / `pnpm update` / Renovate / Dependabot）**: 新規 release が 7 日経過していない場合、その version を resolve しない（防御の主目的）
- **`pnpm install --frozen-lockfile`（CI のメイン経路）**: lockfile 固定なので新版を fetch せず、本設定は事実上 noop
- **Dockerfile に `.npmrc` を COPY する理由**: 万一 CI 上で `--frozen-lockfile` 無しの `pnpm install` を誰かが走らせた場合の保険、および Docker 内 shell に入って `pnpm add` を試した時の挙動を開発者ローカルと統一するため

## `onlyBuiltDependencies` の選定理由

clean install で確認した build script を持つ dep を実コード確認:

| 依存 | 由来 | 許可 | 確認した postinstall の中身 |
| --- | --- | --- | --- |
| `sharp` | direct (Next.js Image 最適化) | ✅ | production runtime で必須のためネイティブビルドを許可 |
| `browser-tabs-lock` | @auth0/auth0-react 経由 | ❌ | `scripts/postinstall.js` は `console.log` の宣伝メッセージのみ。機能影響ゼロ |
| `@parcel/watcher` | eslint-config-next 経由 | ❌ | `install: node scripts/build-from-source.js`（ネイティブビルド）。dev/lint 用途のみ、prebuilt あり、現状 lint/build とも通る |
| `unrs-resolver` | eslint resolver | ❌ | `postinstall: napi-postinstall ... check`（N-API バイナリ check）。lint で使うが現状 lint 通る |

`pnpm install` 後の「Ignored build scripts」警告は意図的に残す（新規 dep 追加時に開発者が気付ける）。

## 効果

- 新版が公開されてから 7 日経過するまで `pnpm add` / `pnpm update` 経由で取得しない
- `sharp` 以外の dep が postinstall などで任意コード実行することをブロック（pnpm 10 のデフォルト挙動を明示宣言で固定）
- e2e 側は将来の dep 追加でも build script を自動的に拒否

## スコープ外

- `pnpm audit` の CI 必須化（false positive 対策コストが高いため別議論）
- `dependabot` / `renovate` の自動更新導入
- pnpm 11 への version up（pnpm 11 ではこれらの設定が一部デフォルト化される）

## 動作確認

- [x] `cd frontend && rm -rf node_modules && pnpm install --frozen-lockfile`（sharp のみ build され、他 3 件は Ignored 維持）
- [x] `cd frontend && pnpm run lint`
- [x] `cd frontend && pnpm run build`
- [x] `cd e2e && rm -rf node_modules && pnpm install --frozen-lockfile`（build script 警告なし）
- [ ] マージ後の `delivery frontend` CI でクリーンビルドが通ることを確認（PR #34 マージ後に Dockerfile 衝突解消のため rebase が必要）

## 備考

- 既存 PR #34（CI 復旧）と独立。PR #34 がマージされてから本 PR を rebase するのが安全
