### PR TITLE
refactor: docker login を --password-stdin 化 (#38)

### DIFF
--- a/.github/workflows/deploy_backend.yml
+++ b/.github/workflows/deploy_backend.yml
@@ -20,8 +20,10 @@ jobs:
           cd backend
           docker build -t ghcr.io/h-orito/chat-role-play-backend .
       - name: deploy
+        env:
+          PACKAGE_PAT: ${{ secrets.PACKAGE_PAT }}
         run: |
-          docker login ghcr.io -u h-orito -p ${{ secrets.PACKAGE_PAT }}
+          echo "$PACKAGE_PAT" | docker login ghcr.io -u h-orito --password-stdin
           docker push ghcr.io/h-orito/chat-role-play-backend
       - name: release
         run: |

--- a/.github/workflows/deploy_backend.yml
+++ b/.github/workflows/deploy_backend.yml
@@ -11,6 +11,9 @@ on:
 jobs:
   delivery:
     runs-on: [self-hosted]
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: clone repository
         uses: actions/checkout@v4
@@ -21,9 +24,10 @@ jobs:
           docker build -t ghcr.io/h-orito/chat-role-play-backend .
       - name: deploy
         env:
-          PACKAGE_PAT: ${{ secrets.PACKAGE_PAT }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ACTOR: ${{ github.actor }}
         run: |
-          echo "$PACKAGE_PAT" | docker login ghcr.io -u h-orito --password-stdin
+          echo "$GITHUB_TOKEN" | docker login ghcr.io -u "$ACTOR" --password-stdin
           docker push ghcr.io/h-orito/chat-role-play-backend
       - name: release
         run: |

--- a/.github/workflows/deploy_frontend.yml
+++ b/.github/workflows/deploy_frontend.yml
@@ -10,6 +10,9 @@ on:
 jobs:
   delivery:
     runs-on: [self-hosted]
+    permissions:
+      contents: read
+      packages: write
     env:
       IMAGE_NAME: chat-role-play-frontend
     steps:
@@ -31,9 +34,10 @@ jobs:
           --build-arg GRAPHQL_INNER_ENDPOINT=${{ secrets.GRAPHQL_INNER_ENDPOINT }}
       - name: deploy
         env:
-          PACKAGE_PAT: ${{ secrets.PACKAGE_PAT }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ACTOR: ${{ github.actor }}
         run: |
-          echo "$PACKAGE_PAT" | docker login ghcr.io -u h-orito --password-stdin
+          echo "$GITHUB_TOKEN" | docker login ghcr.io -u "$ACTOR" --password-stdin
           docker push ghcr.io/h-orito/${{ env.IMAGE_NAME }}
       - name: release
         run: |

--- a/.github/workflows/deploy_frontend.yml
+++ b/.github/workflows/deploy_frontend.yml
@@ -30,8 +30,10 @@ jobs:
           --build-arg GRAPHQL_ENDPOINT=${{ secrets.GRAPHQL_ENDPOINT }}
           --build-arg GRAPHQL_INNER_ENDPOINT=${{ secrets.GRAPHQL_INNER_ENDPOINT }}
       - name: deploy
+        env:
+          PACKAGE_PAT: ${{ secrets.PACKAGE_PAT }}
         run: |
-          docker login ghcr.io -u h-orito -p ${{ secrets.PACKAGE_PAT }}
+          echo "$PACKAGE_PAT" | docker login ghcr.io -u h-orito --password-stdin
           docker push ghcr.io/h-orito/${{ env.IMAGE_NAME }}
       - name: release
         run: |


### PR DESCRIPTION
closes .issues/38-docker-login-password-stdin.md

## 変更内容

- `.github/workflows/deploy_frontend.yml` / `.github/workflows/deploy_backend.yml` の `docker login` を `--password-stdin` 経由に変更
- 認証 token を **`secrets.PACKAGE_PAT` (長期 PAT) から `secrets.GITHUB_TOKEN` (workflow run ごとの一時 token)** に変更
  - job-level `permissions: { contents: read, packages: write }` を付与
  - username は `${{ github.actor }}` を env 経由で渡す
  - `GITHUB_TOKEN` は workflow run 終了時に自動失効

## ユーザー作業（マージ後）

- [ ] GitHub repo settings から `PACKAGE_PAT` secret を削除
- [ ] 初回 push 失敗時は GHCR package 設定の確認:
  - `https://github.com/users/h-orito/packages/container/chat-role-play-{frontend,backend}/settings`
  - 「Manage Actions access」で本リポジトリを Write 権限で紐付け（既存 package を `GITHUB_TOKEN` で push する初回のみ必要）

## 動作確認

- [x] pnpm run lint （No ESLint warnings or errors）
- [ ] ユーザー手動確認依頼: マージ後の GitHub Actions ログから `WARNING! Using --password via the CLI is insecure.` が消えていること、および ghcr.io への push が成功すること

build/E2E は CI workflow yaml のみの変更のため対象外。release-note も CI 変更につき対象外。
