### PR TITLE
feat: 未参加ゲームに参加登録パネルを追加 (#41)

### DIFF
--- a/e2e/tests/dm-and-favorite.spec.ts
+++ b/e2e/tests/dm-and-favorite.spec.ts
@@ -157,7 +157,7 @@ test('複数ユーザーシナリオ：いいね・フォロー・DMグループ
 // ================================================================
 
 async function participateWithCharachip(page: Page): Promise<void> {
-  await page.locator('nav').getByRole('button', { name: '参加登録' }).click()
+  await page.getByRole('button', { name: '参加登録する' }).first().click()
   const dialog = page.getByRole('dialog')
   await expect(dialog).toBeVisible()
   await dialog.locator('#term-check').check()

--- a/e2e/tests/dm-and-favorite.spec.ts
+++ b/e2e/tests/dm-and-favorite.spec.ts
@@ -157,7 +157,10 @@ test('複数ユーザーシナリオ：いいね・フォロー・DMグループ
 // ================================================================
 
 async function participateWithCharachip(page: Page): Promise<void> {
-  await page.getByRole('button', { name: '参加登録する' }).first().click()
+  await page
+    .locator('#article')
+    .getByRole('button', { name: '参加登録する' })
+    .click()
   const dialog = page.getByRole('dialog')
   await expect(dialog).toBeVisible()
   await dialog.locator('#term-check').check()

--- a/e2e/tests/game-flow.spec.ts
+++ b/e2e/tests/game-flow.spec.ts
@@ -53,7 +53,7 @@ test('複数ユーザーシナリオ：ゲーム作成・参加・発言・リ�
 
   // 2. ユーザーA: 参加登録（キャラチップ利用、最初のキャラ）
   await participateWithCharachip(pageA)
-  // 参加後はリロードされ、サイドバーから参加登録ボタンが消えてプロフィールリンクが出る
+  // 参加後はリロードされ、参加登録パネルが消えてプロフィールリンクが出る
   await expect(
     pageA.locator('nav').locator('a[href*="/profile/"]')
   ).toBeVisible({ timeout: 10_000 })
@@ -164,8 +164,8 @@ test('複数ユーザーシナリオ：ゲーム作成・参加・発言・リ�
 // ================================================================
 
 async function participateWithCharachip(page: Page): Promise<void> {
-  // サイドバーの「参加登録」ボタン（モーダル外）
-  await page.locator('nav').getByRole('button', { name: '参加登録' }).click()
+  // メッセージエリアの「参加登録」パネル内ボタン（モーダル外）
+  await page.getByRole('button', { name: '参加登録する' }).first().click()
   // モーダル内の操作
   const dialog = page.getByRole('dialog')
   await expect(dialog).toBeVisible()

--- a/e2e/tests/game-flow.spec.ts
+++ b/e2e/tests/game-flow.spec.ts
@@ -165,7 +165,10 @@ test('複数ユーザーシナリオ：ゲーム作成・参加・発言・リ�
 
 async function participateWithCharachip(page: Page): Promise<void> {
   // メッセージエリアの「参加登録」パネル内ボタン（モーダル外）
-  await page.getByRole('button', { name: '参加登録する' }).first().click()
+  await page
+    .locator('#article')
+    .getByRole('button', { name: '参加登録する' })
+    .click()
   // モーダル内の操作
   const dialog = page.getByRole('dialog')
   await expect(dialog).toBeVisible()

--- a/frontend/src/components/pages/games/article/message-area/message-area/message-area.tsx
+++ b/frontend/src/components/pages/games/article/message-area/message-area/message-area.tsx
@@ -24,6 +24,7 @@ import { emptyMessageQuery } from './messages-query'
 import { useInitialMessagesQuery } from '@/components/pages/games/contexts/messages-query-context'
 import { useUserPagingSettings } from '../../../user-settings'
 import TalkArea from './talk-area'
+import ParticipatePanel from './participate-panel'
 import MessageAreaFooterMenu from './message-area-footer-menu'
 
 type Props = {
@@ -170,6 +171,7 @@ const MessageArea = forwardRef<MessageAreaRefHandle, Props>(
             setExistsUnread={setExistUnread}
           />
           <TalkArea canTalk={canTalk} search={search} talkAreaId={talkAreaId} />
+          {!onlyToMe && <ParticipatePanel />}
         </div>
         <div id={`${talkAreaId}-fixed`}></div>
         <MessageAreaFooterMenu

--- a/frontend/src/components/pages/games/article/message-area/message-area/participate-panel.tsx
+++ b/frontend/src/components/pages/games/article/message-area/message-area/participate-panel.tsx
@@ -1,0 +1,61 @@
+import Panel from '@/components/panel/panel'
+import Modal from '@/components/modal/modal'
+import { LoginButton } from '@/components/auth/auth'
+import PrimaryButton from '@/components/button/primary-button'
+import { useModal } from '@/components/hooks/use-modal'
+import {
+  isGameMaster as _isGameMaster,
+  participateInvitation,
+  useGameValue,
+  useMyPlayerValue,
+  useMyselfValue
+} from '@/components/pages/games/game-hook'
+import Participate from '@/components/pages/games/sidebar/participate'
+
+const ParticipatePanel = () => {
+  const game = useGameValue()
+  const myPlayer = useMyPlayerValue()
+  const myself = useMyselfValue()
+  const isGameMaster = _isGameMaster(myPlayer, game)
+  const invitation = participateInvitation(game, myPlayer, myself, isGameMaster)
+
+  if (invitation === 'hide') return null
+
+  return (
+    <div className='m-4'>
+      <Panel header='参加登録'>
+        {invitation === 'login-required' ? (
+          <LoginRequired />
+        ) : (
+          <ParticipateCta />
+        )}
+      </Panel>
+    </div>
+  )
+}
+
+export default ParticipatePanel
+
+const LoginRequired = () => (
+  <div>
+    <p className='mb-3 text-sm'>このゲームに参加するにはログインが必要です。</p>
+    <LoginButton />
+  </div>
+)
+
+const ParticipateCta = () => {
+  const modal = useModal()
+  return (
+    <div>
+      <p className='mb-3 text-sm'>
+        このゲームに参加登録できます。下のボタンから登録してください。
+      </p>
+      <PrimaryButton click={modal.open}>参加登録する</PrimaryButton>
+      {modal.isOpen && (
+        <Modal header='参加登録' close={modal.close} hideFooter>
+          <Participate close={modal.close} />
+        </Modal>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/pages/games/article/message-area/message-area/participate-panel.tsx
+++ b/frontend/src/components/pages/games/article/message-area/message-area/participate-panel.tsx
@@ -4,7 +4,6 @@ import { LoginButton } from '@/components/auth/auth'
 import PrimaryButton from '@/components/button/primary-button'
 import { useModal } from '@/components/hooks/use-modal'
 import {
-  isGameMaster as _isGameMaster,
   participateInvitation,
   useGameValue,
   useMyPlayerValue,
@@ -16,8 +15,7 @@ const ParticipatePanel = () => {
   const game = useGameValue()
   const myPlayer = useMyPlayerValue()
   const myself = useMyselfValue()
-  const isGameMaster = _isGameMaster(myPlayer, game)
-  const invitation = participateInvitation(game, myPlayer, myself, isGameMaster)
+  const invitation = participateInvitation(game, myPlayer, myself)
 
   if (invitation === 'hide') return null
 

--- a/frontend/src/components/pages/games/game-hook.ts
+++ b/frontend/src/components/pages/games/game-hook.ts
@@ -69,6 +69,27 @@ export const canParticipate = (
     playerParticipatableGameStatuses.includes(game.status)
   )
 }
+export type ParticipateInvitation = 'hide' | 'login-required' | 'participate'
+// 参加登録パネルの表示状態
+// - 参加済み → 'hide'
+// - ログイン済み: canParticipate に従う
+// - 未ログイン: プレイヤー参加可能ステータスのみ案内（GM 判定はログイン後）
+export const participateInvitation = (
+  game: Game,
+  player: Player | null,
+  myself: GameParticipant | null,
+  isGameMasterValue: boolean
+): ParticipateInvitation => {
+  if (myself) return 'hide'
+  if (player) {
+    return canParticipate(game, player, myself, isGameMasterValue)
+      ? 'participate'
+      : 'hide'
+  }
+  return playerParticipatableGameStatuses.includes(game.status)
+    ? 'login-required'
+    : 'hide'
+}
 // ゲーム設定変更可能か
 export const canModifyGameSetting = (game: Game, myPlayer: Player | null) => {
   return (

--- a/frontend/src/components/pages/games/game-hook.ts
+++ b/frontend/src/components/pages/games/game-hook.ts
@@ -71,9 +71,12 @@ export const canParticipate = (
 }
 export type ParticipateInvitation = 'hide' | 'login-required' | 'participate'
 // 参加登録パネルの表示状態
-// - 参加済み → 'hide'
-// - ログイン済み: canParticipate に従う（GM 判定込み）
+// - 参加済み (myself != null) → 'hide'
+// - ログイン済み未参加: canParticipate に従う（GM 判定込み）
 // - 未ログイン: プレイヤー参加可能ステータスのみ案内（GM 判定はログイン後）
+//
+// 引数 myself は冒頭の「参加済みガード」専用。以降の canParticipate 呼び出しでは
+// 既に myself == null が確定しているため、第3引数には null リテラルを渡す。
 export const participateInvitation = (
   game: Game,
   player: Player | null,

--- a/frontend/src/components/pages/games/game-hook.ts
+++ b/frontend/src/components/pages/games/game-hook.ts
@@ -72,17 +72,16 @@ export const canParticipate = (
 export type ParticipateInvitation = 'hide' | 'login-required' | 'participate'
 // 参加登録パネルの表示状態
 // - 参加済み → 'hide'
-// - ログイン済み: canParticipate に従う
+// - ログイン済み: canParticipate に従う（GM 判定込み）
 // - 未ログイン: プレイヤー参加可能ステータスのみ案内（GM 判定はログイン後）
 export const participateInvitation = (
   game: Game,
   player: Player | null,
-  myself: GameParticipant | null,
-  isGameMasterValue: boolean
+  myself: GameParticipant | null
 ): ParticipateInvitation => {
   if (myself) return 'hide'
   if (player) {
-    return canParticipate(game, player, myself, isGameMasterValue)
+    return canParticipate(game, player, null, isGameMaster(player, game))
       ? 'participate'
       : 'hide'
   }

--- a/frontend/src/components/pages/games/sidebar/sidebar.tsx
+++ b/frontend/src/components/pages/games/sidebar/sidebar.tsx
@@ -4,7 +4,6 @@ import {
   InformationCircleIcon,
   WrenchIcon,
   UserCircleIcon,
-  UserPlusIcon,
   HomeIcon,
   LockClosedIcon
 } from '@heroicons/react/24/outline'
@@ -12,7 +11,6 @@ import { useMemo } from 'react'
 import { useModal } from '@/components/hooks/use-modal'
 import GameSettings from './game-settings'
 import Modal from '@/components/modal/modal'
-import Participate from './participate'
 import ArticleModal from '@/components/modal/article-modal'
 import Participants from '../participant/participants'
 import Link from 'next/link'
@@ -29,8 +27,6 @@ import UserSettingsComponent from './user-settings'
 import { GameIntroButton } from './game-intro-modal'
 import { DebugMenu } from './debug-menu'
 import {
-  isGameMaster as _isGameMaster,
-  canParticipate as _canParticipate,
   canModifyGameSetting,
   useGameValue,
   useMyPlayerValue,
@@ -44,8 +40,6 @@ export default function Sidebar() {
   const myself = useMyselfValue()
   const myPlayer = useMyPlayerValue()
 
-  const isGameMaster = _isGameMaster(myPlayer, game)
-  const canParticipate = _canParticipate(game, myPlayer, myself, isGameMaster)
   const canModify = canModifyGameSetting(game, myPlayer)
 
   const displayClass = isSidebarOpen
@@ -79,11 +73,6 @@ export default function Sidebar() {
           </div>
         )}
         <DebugMenu />
-        {canParticipate && (
-          <div className='base-border border-t py-2'>
-            <ParticipateButton />
-          </div>
-        )}
         <div className='base-border border-t py-2'>
           <TopPageButton />
         </div>
@@ -301,26 +290,6 @@ const ProfileButton = () => {
         <UserCircleIcon className='mr-1 size-5' />
         <p className='flex-1 self-center text-left'>{myself.name}</p>
       </Link>
-    </>
-  )
-}
-
-const ParticipateButton = () => {
-  const modal = useModal()
-  return (
-    <>
-      <button
-        className='sidebar-text sidebar-hover flex w-full justify-start px-4 py-2 text-sm'
-        onClick={modal.open}
-      >
-        <UserPlusIcon className='mr-1 size-5' />
-        <p className='flex-1 self-center text-left'>参加登録</p>
-      </button>
-      {modal.isOpen && (
-        <Modal header='参加登録' close={modal.close} hideFooter>
-          <Participate close={modal.close} />
-        </Modal>
-      )}
     </>
   )
 }

--- a/frontend/src/pages/release-note.tsx
+++ b/frontend/src/pages/release-note.tsx
@@ -25,6 +25,13 @@ export default function CreateGame() {
 
           <hr />
 
+          <ReleaseContent label='機能拡張' date='2026/05/14'>
+            <li>
+              改善:
+              ゲーム画面のメッセージ下に「参加登録」パネルを追加（未参加かつ参加可能なステータスの場合のみ表示）。未ログインの場合はログイン案内を表示。左メニューの参加登録ボタンは廃止
+            </li>
+          </ReleaseContent>
+
           <ReleaseContent label='機能拡張' date='2026/05/13'>
             <li>
               追加: ゲームの公開設定（公開/非公開）を追加。非公開設定の


### PR DESCRIPTION
closes .issues/41-participate-panel.md

## 変更内容

メッセージエリア下に「参加登録」パネルを表示し、未ログイン/未参加ユーザーの導線を改善:

- **未ログイン & 参加可能ステータス**: 「このゲームに参加するにはログインが必要です。」+ ログインボタン
- **ログイン済み & 未参加 & 参加可能ステータス**: 「参加登録する」ボタン → 既存の参加登録モーダル
- **参加済み or 参加不可ステータス**: 非表示

その他:

- 左サイドバーの「参加登録」ボタン (`ParticipateButton`) を廃止（重複導線整理）。`UserPlusIcon` の不要 import / `canParticipate` import / `isGameMaster` ローカル変数も併せて削除
- 表示判定ヘルパー `participateInvitation` を `game-hook.ts` に追加（既存 `canParticipate` は再利用）
- 既存 `Participate` モーダルと既存 `LoginButton` をそのまま再利用
- E2E ヘルパー (`participateWithCharachip`) をサイドバー経由から新パネル経由に追従
- Panel ヘッダーと CTA ボタンのアクセシブル名衝突を避けるため、ボタン文言は「参加登録する」

## 動作確認

- [x] `cd frontend && pnpm run lint` (✔ No warnings or errors)
- [x] `cd frontend && pnpm run build` (✔ 成功)
- [x] 既存 E2E: `cd e2e && pnpm exec playwright test` (4 passed / 30.2s)
- [ ] ユーザー手動確認依頼:
  - 未ログインで募集中ゲームを開く → メッセージエリア下に参加登録パネル + ログインボタンが表示される
  - ログイン済み未参加で募集中ゲーム → 「参加登録する」ボタンから既存モーダル経由で参加完了まで通せる
  - 参加済みアカウントでゲームを開く → パネル非表示、発言パネルのみ表示
  - Finished/中止など参加不可ステータスのゲーム → パネル非表示
  - スマホビュー（サイドバー非表示）でも参加導線が見える