### PR TITLE
ci: build/push を GitHub 公式 ARM ランナーで実行

### DIFF
--- a/.github/workflows/deploy_backend.yml
+++ b/.github/workflows/deploy_backend.yml
@@ -7,13 +7,16 @@ on:
       - main
     paths:
       - "backend/**"
+      - ".github/workflows/deploy_backend.yml"
 
 jobs:
-  delivery:
-    runs-on: [self-hosted]
+  build:
+    runs-on: ubuntu-24.04-arm
     permissions:
       contents: read
       packages: write
+    env:
+      IMAGE_NAME: chat-role-play-backend
     steps:
       - name: clone repository
         uses: actions/checkout@v4
@@ -21,14 +24,21 @@ jobs:
       - name: build
         run: |
           cd backend
-          docker build -t ghcr.io/h-orito/chat-role-play-backend .
-      - name: deploy
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          ACTOR: ${{ github.actor }}
-        run: |
-          echo "$GITHUB_TOKEN" | docker login ghcr.io -u "$ACTOR" --password-stdin
-          docker push ghcr.io/h-orito/chat-role-play-backend
+          docker build -t ghcr.io/h-orito/${{ env.IMAGE_NAME }} .
+
+      - name: login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: push image
+        run: docker push ghcr.io/h-orito/${{ env.IMAGE_NAME }}
+
+  deploy:
+    needs: build
+    runs-on: [self-hosted]
+    steps:
       - name: release
-        run: |
-          kubectl delete pod -l app=chat-role-play-backend
+        run: kubectl rollout restart deployment/chat-role-play-backend

--- a/.github/workflows/deploy_frontend.yml
+++ b/.github/workflows/deploy_frontend.yml
@@ -7,19 +7,17 @@ on:
       - main
     paths:
       - "frontend/**"
+      - ".github/workflows/deploy_frontend.yml"
+
 jobs:
-  delivery:
-    runs-on: [self-hosted]
+  build:
+    runs-on: ubuntu-24.04-arm
     permissions:
       contents: read
       packages: write
     env:
       IMAGE_NAME: chat-role-play-frontend
     steps:
-      - name: setup
-        run: |
-          docker system prune --force
-
       - name: clone repository
         uses: actions/checkout@v4
 
@@ -31,13 +29,20 @@ jobs:
           --build-arg AUTH0_CLIENT_ID=${{ secrets.AUTH0_CLIENT_ID }}
           --build-arg AUTH0_AUDIENCE=${{ secrets.AUTH0_AUDIENCE }}
           --build-arg GRAPHQL_ENDPOINT=${{ secrets.GRAPHQL_ENDPOINT }}
-      - name: deploy
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          ACTOR: ${{ github.actor }}
-        run: |
-          echo "$GITHUB_TOKEN" | docker login ghcr.io -u "$ACTOR" --password-stdin
-          docker push ghcr.io/h-orito/${{ env.IMAGE_NAME }}
+
+      - name: login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: push image
+        run: docker push ghcr.io/h-orito/${{ env.IMAGE_NAME }}
+
+  deploy:
+    needs: build
+    runs-on: [self-hosted]
+    steps:
       - name: release
-        run: |
-          kubectl delete pod -l app=chat-role-play-frontend
+        run: kubectl rollout restart deployment/chat-role-play-frontend


### PR DESCRIPTION
## Summary

- `build` ジョブを GitHub 公式 ARM ランナー `ubuntu-24.04-arm` に分離し、`deploy` ジョブだけを self-hosted で実行
- `docker login` を `docker/login-action@v3` に置き換え
- frontend の `docker system prune --force` を削除（不要）
- k8s 反映を `kubectl delete pod` から `kubectl rollout restart deployment/<name>` に変更
- workflow ファイル自身を `paths` トリガに追加（自身の変更でも発火）

参考: [firewolf/.github/workflows/deploy.yml](https://github.com/h-orito/firewolf/blob/main/.github/workflows/deploy.yml)

## Test plan

- [ ] backend を変更した push で `delivery backend` が green になる
- [ ] frontend を変更した push で `delivery frontend` が green になる
- [ ] 各 deployment（`chat-role-play-backend` / `chat-role-play-frontend`）が rollout restart で再起動される