### PR TITLE
ci: deploy ジョブの runs-on に k8s ラベルを追加

### DIFF
--- a/.github/workflows/deploy_backend.yml
+++ b/.github/workflows/deploy_backend.yml
@@ -38,7 +38,7 @@ jobs:
 
   deploy:
     needs: build
-    runs-on: [self-hosted]
+    runs-on: [self-hosted, k8s]
     steps:
       - name: release
         run: kubectl rollout restart deployment/chat-role-play-backend

--- a/.github/workflows/deploy_frontend.yml
+++ b/.github/workflows/deploy_frontend.yml
@@ -42,7 +42,7 @@ jobs:
 
   deploy:
     needs: build
-    runs-on: [self-hosted]
+    runs-on: [self-hosted, k8s]
     steps:
       - name: release
         run: kubectl rollout restart deployment/chat-role-play-frontend


### PR DESCRIPTION
## Summary

- `deploy` ジョブの `runs-on` を `[self-hosted]` → `[self-hosted, k8s]` に変更
- self-hosted runner のうち k8s 操作可能なノードに振り分けるため

参考: [lastwolf/.github/workflows/deploy.yml](https://github.com/h-orito/lastwolf/blob/main/.github/workflows/deploy.yml)

## Test plan

- [ ] backend / frontend それぞれの workflow_dispatch で deploy ジョブが k8s ラベル付き runner にアサインされる
- [ ] rollout restart が成功する