### PR TITLE
ci: deploy ジョブに azure/setup-kubectl を追加

### DIFF
--- a/.github/workflows/deploy_backend.yml
+++ b/.github/workflows/deploy_backend.yml
@@ -40,5 +40,10 @@ jobs:
     needs: build
     runs-on: [self-hosted, k8s]
     steps:
+      - name: setup kubectl
+        uses: azure/setup-kubectl@v4
+        with:
+          version: latest
+
       - name: release
         run: kubectl rollout restart deployment/chat-role-play-backend

--- a/.github/workflows/deploy_frontend.yml
+++ b/.github/workflows/deploy_frontend.yml
@@ -44,5 +44,10 @@ jobs:
     needs: build
     runs-on: [self-hosted, k8s]
     steps:
+      - name: setup kubectl
+        uses: azure/setup-kubectl@v4
+        with:
+          version: latest
+
       - name: release
         run: kubectl rollout restart deployment/chat-role-play-frontend


### PR DESCRIPTION
## Summary

- `deploy` ジョブの `release` 前に `azure/setup-kubectl@v4` で kubectl を導入
- self-hosted runner に kubectl が事前インストールされていないケースに対応

参考: [lastwolf/.github/workflows/deploy.yml](https://github.com/h-orito/lastwolf/blob/main/.github/workflows/deploy.yml)

## Test plan

- [ ] backend / frontend それぞれで deploy ジョブの `setup kubectl` が成功
- [ ] `kubectl rollout restart` が成功