### PR TITLE
ci: rollout restart に -n default を明示

### DIFF
--- a/.github/workflows/deploy_backend.yml
+++ b/.github/workflows/deploy_backend.yml
@@ -46,4 +46,4 @@ jobs:
           version: latest
 
       - name: release
-        run: kubectl rollout restart deployment/chat-role-play-backend
+        run: kubectl rollout restart deployment/chat-role-play-backend -n default

--- a/.github/workflows/deploy_frontend.yml
+++ b/.github/workflows/deploy_frontend.yml
@@ -50,4 +50,4 @@ jobs:
           version: latest
 
       - name: release
-        run: kubectl rollout restart deployment/chat-role-play-frontend
+        run: kubectl rollout restart deployment/chat-role-play-frontend -n default


### PR DESCRIPTION
## Summary

- `kubectl rollout restart deployment/<name>` に `-n default` を追加し、対象 namespace を明示

## Test plan

- [ ] backend / frontend それぞれの deploy ジョブが default namespace の deployment を再起動する